### PR TITLE
Add managed my.cnf for CentOS

### DIFF
--- a/mysql/files/CentOS-my.cnf
+++ b/mysql/files/CentOS-my.cnf
@@ -1,0 +1,13 @@
+[mysqld]
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+user={{ salt['pillar.get']('mysql:server:user', 'mysql') }}
+port={{ salt['pillar.get']('mysql:server:port', '3306') }}
+bind-address={{ salt['pillar.get']('mysql:server:bind-address', '127.0.0.1') }}
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+[mysqld_safe]
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid
+

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -31,7 +31,7 @@ mysql-python:
     - installed
     - name: {{ mysql.python }}
 
-{% if grains['os'] in ['Ubuntu', 'Debian', 'Gentoo'] %}
+{% if grains['os'] in ['Ubuntu', 'Debian', 'Gentoo', 'CentOS'] %}
 my.cnf:
   file.managed:
     - name: {{ mysql.config }}


### PR DESCRIPTION
This adds my.cnf for CentOS distribution. The config is adapted from the one shipped with CentOS mysql-server.

It could probably be used for RedHad as well, though I have no access to any RHEL distro installation so I didn't add it to the sls.
