### PR TITLE
Set MySQL root password for CentOS and remove anonymous user

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -1,14 +1,38 @@
 {% from "mysql/map.jinja" import mysql with context %}
 
+{% set mysql_root_password = salt['pillar.get']('mysql:server:root_password', 'somepass') %}
 
 {% if grains['os'] in ['Ubuntu', 'Debian'] %}
 mysql-debconf:
   debconf.set:
     - name: mysql-server
     - data:
-        'mysql-server/root_password': {'type': 'password', 'value': '{{ salt['pillar.get']('mysql:server:root_password', 'somepass') }}'}
-        'mysql-server/root_password_again': {'type': 'password', 'value': '{{ salt['pillar.get']('mysql:server:root_password', 'somepass') }}'}
+        'mysql-server/root_password': {'type': 'password', 'value': '{{ mysql_root_password }}'}
+        'mysql-server/root_password_again': {'type': 'password', 'value': '{{ mysql_root_password }}'}
         'mysql-server/start_on_boot': {'type': 'boolean', 'value': 'true'}
+{% elif grains['os'] in ['CentOS'] %}
+mysql-root-password:
+  cmd:
+    - run
+    - name: mysqladmin --user root password '{{ mysql_root_password|replace("'", "'\"'\"'") }}'
+    - unless: mysql --user root --password='{{ mysql_root_password|replace("'", "'\"'\"'") }}' --execute="SELECT 1;"
+    - require:
+      - service: mysqld
+
+{% for host in ['localhost', grains['fqdn']] %}
+mysql-delete-anonymous-user-{{ host }}:
+  mysql_user:
+    - absent
+    - host: {{ host }}
+    - name: ''
+    - connection_pass: {{ mysql_root_password }}
+    - require:
+      - service: mysqld
+      - pkg: mysql-python
+      {%- if mysql_root_password %}
+      - cmd: mysql-root-password
+      {%- endif %}
+{% endfor %}
 {% endif %}
 
 mysqld:


### PR DESCRIPTION
Again, this _could_ work on RedHat, though I haven't checked it.

Also, apart from setting up root password a user with empty name is deleted. Otherwise weird access denied errors happen when trying to authorize from remote hosts.

Debian package performs anynomous user cleanup during installation so it's only necessary for CentOS (and probably RHEL).
