### PR TITLE
Removed disabling SELinux prereq; no longer needed

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -68,23 +68,6 @@ my.cnf:
       - service: mysqld
 {% endif %}
 
-# Set SELinux to permissive mode while installing mysqld otherwise the
-# mysql user will not be created; restore enforcing when done.
-{% if (grains['os_family'] == 'RedHat'
-    and salt['cmd.run']("sestatus | awk '/Current mode/ { print $3 }'") == 'enforcing') %}
-selinux_permissive:
-  cmd.run:
-    - name: setenforce permissive
-    - prereq:
-      - pkg: mysqld
-
-selinux_enforcing:
-  cmd.wait:
-    - name: setenforce enforcing
-    - watch_in:
-      - pkg: mysqld
-{% endif %}
-
 {% if grains['os'] in 'FreeBSD' %}
 my.cnf:
   file.managed:


### PR DESCRIPTION
This SELinux problem was caused by the yumpkg.py module that used the
yum Python interface for CentOS 6 machines. That was removed in favor of
the yumpkg.py that shells out to yum which does not have this problem.
This workaround can be removed.
