### PR TITLE
Fixed state names without proper namespacing

### DIFF
--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -4,7 +4,7 @@ include:
   - mysql.python
 
 {% for database in salt['pillar.get']('mysql:database', []) %}
-{{ database }}:
+mysql_db_{{ database }}:
   mysql_database.present:
     - host: localhost
     - connection_user: root

--- a/mysql/user.sls
+++ b/mysql/user.sls
@@ -4,8 +4,9 @@ include:
   - mysql.python
 
 {% for user in salt['pillar.get']('mysql:user', []) %}
-{{ user['name'] }}:
+mysql_user_{{ user['name'] }}:
   mysql_user.present:
+    - name: {{ user['name'] }}
     - host: {{ user['host'] }}
   {%- if user['password_hash'] is defined %}
     - password_hash: '{{ user['password_hash'] }}'
@@ -18,8 +19,10 @@ include:
     - connection_charset: utf8
 
 {% for db in user['databases'] %}
-{{ user['name'] }}_{{ db['database'] }}:
+{% set name = user['name'] ~ '_' ~ db['database'] %}
+mysql_user_{{ name }}:
   mysql_grants.present:
+    - name: {{ name }}
     - grant: {{db['grants']|join(",")}}
     - database: {{ db['database'] }}.*
     - user: {{ user['name'] }}


### PR DESCRIPTION
Some of the state names were not properly namespaced to 'mysql_xxx' and could have conflicts with other formulas/states.
