### PR TITLE
Add name declaration to database creation in database.sls

### DIFF
--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -6,6 +6,7 @@ include:
 {% for database in salt['pillar.get']('mysql:database', []) %}
 mysql_db_{{ database }}:
   mysql_database.present:
+    - name: {{ database }}
     - host: localhost
     - connection_user: root
     - connection_pass: '{{ salt['pillar.get']('mysql:server:root_password', 'somepass') }}'


### PR DESCRIPTION
After the change to the id declaration in database.sls, databases are not being named as specified in the pillar.

Adding   "- name: {{ database }} " fixes this.
