### PR TITLE
backed out rand_str calls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,9 @@ debconf.
 .. note::
 
     If no root password is provided in the pillar, a random one will
-    be created. As-of Hydrogen, this password uses the Python ``random``
-    module via ``test.rand_str``. As ``random`` is considered
+    be created. Because Hydrogen doesn't have easy access to a random
+    function (test.rand_str isn't introduced until Helium), instead,
+    we use the not-at-all random ``grains.server_id``. As this is
     cryptographically insecure, future formula versions should use the
     newly available ``random.get_str`` method.
 

--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -1,6 +1,6 @@
 {% from "mysql/map.jinja" import mysql with context %}
 
-{% set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', salt['test.rand_str'](64)) %}
+{% set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
 {% set db_states = [] %}
 
 include:

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -2,7 +2,7 @@
 
 {% set os = salt['grains.get']('os', None) %}
 {% set os_family = salt['grains.get']('os_family', None) %}
-{% set mysql_root_password = salt['pillar.get']('mysql:server:root_password', salt['test.rand_str'](64)) %}
+{% set mysql_root_password = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
 
 {% if os in ['Ubuntu', 'Debian'] %}
 mysql_debconf:


### PR DESCRIPTION
test.rand_str doesn't exist in Hydrogen. I picked grains.server_id mostly because it was easy, but I'm not confident it's always available.
