### PR TITLE
clever way to load DB schemas in 2014.1

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -9,6 +9,12 @@ mysql:
   database:
     - foo
     - bar
+  schema:
+    foo:
+      load: True
+      source: salt://mysql/files/foo.schema
+    bar:
+      load: False
 
   # Manage users
   user:


### PR DESCRIPTION
Since there isn't (yet?) a way to describe DB schemas to mysql using salt, here's a reasonably clever (but hopefully not-too-clever) approach.
