### PR TITLE
Fix broken state / my.cnf file

### DIFF
--- a/mysql/files/my.cnf
+++ b/mysql/files/my.cnf
@@ -28,4 +28,3 @@
 	{%- endif %}
 	{%- endfor %}
 {% endfor %}
-{{ datamap.config.append }}


### PR DESCRIPTION
This output/call at the end of the templated my.cnf file causes the `mysql.server` state to fail, erroring that:

```
Unable to manage file: Jinja variable 'dict' object has no attribute 'append'
```

`datamap.config` appears to be a dict object, so outputting it here with the double braces seems illogical, perhaps this was inadvertently added in the recent code updates?  Removing the line generates a valid my.cnf.
