### PR TITLE
Ensure all anonymous users are removed; ensure None values for fqdn are handled for YAML

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -24,11 +24,14 @@ mysql_root_password:
     - require:
       - service: mysqld
 
-{% for host in ['localhost', salt['grains.get']('fqdn')] %}
+include:
+  - mysql.python
+
+{% for host in ['localhost', 'localhost.localdomain', salt['grains.get']('fqdn')] %}
 mysql_delete_anonymous_user_{{ host }}:
   mysql_user:
     - absent
-    - host: {{ host }}
+    - host: {{ host or "''" }}
     - name: ''
     - connection_host: localhost
     - connection_user: root


### PR DESCRIPTION
This ensures all anonymous users are removed; on CentOS 6.5 (at least), there is also a 'localhost.localdomain' anonymous user.  

Also, if the FQDN grain is None, then an empty space rendered in YAML translates to None, rather than an empty string.  This was causing the state to attempt to remove the user `@None`, which isn't correct.
