### PR TITLE
Add state for removal of test database

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,9 @@ Available states
 
 Meta-state that includes all server packages in the correct order.
 
+This meta-state does **not** include ``mysql.remove_test_database``; see
+below for details.
+
 ``mysql.client``
 ----------------
 
@@ -67,6 +70,17 @@ priority.
 
     Make sure to **quote the passwords** in the pillar so YAML doesn't throw an exception.
 
+``mysql.remove_test_database``
+------------------------------
+
+.. warning::
+
+   Do not use this state if your MySQL instance has a database in use called ``test``.
+   If you do, it will be irrevocably removed!
+
+Remove the database called ``test``, normally created as part of a default
+MySQL installation.  This state is **not** included as part of the meta-state
+above as this name may conflict with a real database.
 
 Updating the supported parameters
 =================================

--- a/mysql/remove_test_database.sls
+++ b/mysql/remove_test_database.sls
@@ -1,0 +1,14 @@
+{% set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
+
+include:
+  - mysql.python
+
+mysql remove test database:
+  mysql_database.absent:
+    - name: test
+    - host: localhost
+    - connection_user: root
+    {% if mysql_root_pass %}
+    - connection_pass: '{{ mysql_root_pass }}'
+    {% endif %}
+    - connection_charset: utf8


### PR DESCRIPTION
MySQL typically ships with a `test` database created.  This state allows users to ensure this database is removed.  

This state is **not** engaged by default, nor part of the main `mysql` metastate, as someone might actually have a database named `test` or be using this default database for real data.  This is explained clearly in the readme.
