### PR TITLE
Use a dict instead of a list for users

### DIFF
--- a/import_users.py
+++ b/import_users.py
@@ -56,7 +56,7 @@ for user in users:
 """ PRINT EXAMPLE
 mysql:
   user:
-    - name: user
+    username:
       host: host
       password_hash: '*2792A97371B2D17789364A22A9B35D180166571A'
       databases:
@@ -67,7 +67,7 @@ mysql:
 print "mysql:"
 print "  user:"
 for user in users:
-	print "    - name: %s" % user['name']
+	print "    %s:" % user['name']
 	print "      host: '%s'" % user['host']
 	if ('password' in user):
 		print "      password_hash: '%s'" % user['password']

--- a/mysql/user.sls
+++ b/mysql/user.sls
@@ -7,11 +7,11 @@
 include:
   - mysql.python
 
-{% for user in salt['pillar.get']('mysql:user', []) %}
+{% for name, user in salt['pillar.get']('mysql:user', {}).items() %}
 {% set state_id = 'mysql_user_' ~ loop.index0 %}
 {{ state_id }}:
   mysql_user.present:
-    - name: {{ user['name'] }}
+    - name: {{ name }}
     - host: '{{ user['host'] }}'
   {%- if user['password_hash'] is defined %}
     - password_hash: '{{ user['password_hash'] }}'
@@ -30,11 +30,11 @@ include:
 {% for db in user['databases'] %}
 {{ state_id ~ '_' ~ loop.index0 }}:
   mysql_grants.present:
-    - name: {{ user['name'] ~ '_' ~ db['database']  ~ '_' ~ db['table'] | default('all') }}
+    - name: {{ name ~ '_' ~ db['database']  ~ '_' ~ db['table'] | default('all') }}
     - grant: {{db['grants']|join(",")}}
     - database: '{{ db['database'] }}.{{ db['table'] | default('*') }}'
     - grant_option: {{ db['grant_option'] | default(False) }}
-    - user: {{ user['name'] }}
+    - user: {{ name }}
     - host: '{{ user['host'] }}'
     - connection_host: localhost
     - connection_user: root
@@ -43,7 +43,7 @@ include:
     {% endif %}
     - connection_charset: utf8
     - require:
-      - mysql_user: {{ user['name'] }}
+      - mysql_user: {{ name }}
 {% endfor %}
 
 {% do user_states.append(state_id) %}

--- a/pillar.example
+++ b/pillar.example
@@ -29,7 +29,7 @@ mysql:
   # Manage users
   # you can get pillar for existent server using import_users.py script
   user:
-    - name: frank
+    frank:
       password: 'somepass'
       host: localhost
       databases:
@@ -37,7 +37,7 @@ mysql:
           grants: ['select', 'insert', 'update']
         - database: bar
           grants: ['all privileges']
-    - name: bob
+    bob:
       password_hash: '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'
       host: localhost
       databases:
@@ -47,7 +47,7 @@ mysql:
         - database: bar
           table: foobar
           grants: ['select', 'insert', 'update', 'delete']
-    - name: nopassuser
+    nopassuser:
       password: ~
       host: localhost
       databases: []


### PR DESCRIPTION
My main motivation for making this change is so that you can do things like:

`{{ salt['pillar.get']('mysql:user:db_user:password', 'pass') }}`
`{{ salt['pillar.get']('mysql:user:db_user:host', 'localhost') }}`

Which otherwise I wasn't able to figure out in a clean way. Also, dict seems more consistent with some of the other formulas I've been using so far:
https://github.com/saltstack-formulas/users-formula/blob/master/pillar.example
https://github.com/saltstack-formulas/apache-formula/blob/master/pillar.example

Edit: and if I'm not mistaken this also means you can easily separate your users into separate pillar files.
