### PR TITLE
add Amazon support to defaults config file

### DIFF
--- a/mysql/defaults.yaml
+++ b/mysql/defaults.yaml
@@ -121,6 +121,24 @@ RedHat:
         port: 3306
         bind-address: 127.0.0.1
         symbolic-links: 0
+Amazon:
+  server: mysql-server
+  client: mysql
+  service: mysqld
+  python: MySQL-python
+  config:
+    file: /etc/my.cnf
+    sections:
+      mysqld_safe:
+        log-error: /var/log/mysqld.log
+        pid-file: /var/run/mysqld/mysqld.pid
+      mysqld:
+        datadir: /var/lib/mysql
+        socket: /var/lib/mysql/mysql.sock
+        user: mysql
+        port: 3306
+        bind-address: 127.0.0.1
+        symbolic-links: 0
 Gentoo:
   server: dev-db/mysql
   client: dev-db/mysql


### PR DESCRIPTION
When using this formula on an Amazon AMI, the compilation fails because the os grain is Amazon which doesn't exist in defaults.yaml. I've added support for Amazon based on RedHat defaults.
