### PR TITLE
Ensure that debconf-utils is installed on Debian systems

### DIFF
--- a/mysql/defaults.yaml
+++ b/mysql/defaults.yaml
@@ -5,6 +5,7 @@ Ubuntu:
   client: mysql-client
   service: mysql
   python: python-mysqldb
+  debconf_utils: debconf-utils
   config:
     file: /etc/mysql/my.cnf
     sections:
@@ -48,6 +49,7 @@ Debian:
   client: mysql-client
   service: mysql
   python: python-mysqldb
+  debconf_utils: debconf-utils
   config:
     file: /etc/mysql/my.cnf
     sections:

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -7,6 +7,10 @@
 
 {% if mysql_root_password %}
 {% if os_family == 'Debian' %}
+mysql_debconf_utils:
+  pkg.installed:
+    - name: {{ mysql.debconf_utils }}
+
 mysql_debconf:
   debconf.set:
     - name: mysql-server
@@ -16,6 +20,8 @@ mysql_debconf:
         'mysql-server/start_on_boot': {'type': 'boolean', 'value': 'true'}
     - require_in:
       - pkg: mysqld
+    - require:
+      - pkg: mysql_debconf_utils
 {% elif os_family == 'RedHat' %}
 mysql_root_password:
   cmd.run:


### PR DESCRIPTION
debconf.set which is used in mysql.server has a dependency on debconf-utils. If
it is not installed the password will not be set and is cumbersome to change
later on.
