### PR TITLE
Sort options in my.cnf

### DIFF
--- a/mysql/files/my.cnf
+++ b/mysql/files/my.cnf
@@ -26,7 +26,7 @@
 {%- if sdata %}
 
 [{{ sname }}]
-{%- for mparam, mvalue in sdata.items()|default([]) -%}
+{%- for mparam, mvalue in sdata.items()|default([])|sort -%}
 {%- set indents = 40 - mparam|count %}
 {% if mvalue == "noarg_present" -%}
 {{ mparam }}


### PR DESCRIPTION
Options in my.cnf are not sorted at this moment which introduces unnecessary
changes whenever the file is being rewritten.