### PR TITLE
Added ability for SQL Schemas to be templates

### DIFF
--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -24,6 +24,10 @@ include:
   file.managed:
     - name: /etc/mysql/{{ database }}.schema
     - source: {{ salt['pillar.get'](['mysql', 'schema', database, 'source']|join(':')) }}
+{%- set template_type = salt['pillar.get'](['mysql', 'schema', database, 'template']|join(':'), False) %}
+{%- if template_type %}
+    - template: {{ template_type }}
+{% endif %}
     - user: {{ salt['pillar.get']('mysql:server:user', 'mysql') }}
     - makedirs: True
 

--- a/pillar.example
+++ b/pillar.example
@@ -25,6 +25,10 @@ mysql:
       source: salt://mysql/files/foo.schema
     bar:
       load: False
+    baz:
+      load: True
+      source: salt://mysql/files/baz.schema.tmpl
+      template: jinja
 
   # Manage users
   # you can get pillar for existent server using scripts/import_users.py script


### PR DESCRIPTION
You can now optionally specify a `template: jinja` pillar and the source will be treated as a Jinja template.

This essentially extends the templating of the `file` state to SQL schemas.

Added a pillar.example showing how to do it, e.g.

```yaml
mysql:
  schema:
    baz:
      load: True
      source: salt://mysql/files/baz.schema.tmpl
      template: jinja
```