### PR TITLE
Add possibility of using another host (for db and user management)

### DIFF
--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -2,6 +2,7 @@
 {%- set mysql = salt['grains.filter_by'](rawmap, grain='os', merge=salt['pillar.get']('mysql:lookup')) %}
 
 {% set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
+{% set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost') %}
 {% set db_states = [] %}
 
 include:
@@ -12,7 +13,7 @@ include:
 {{ state_id }}:
   mysql_database.present:
     - name: {{ database }}
-    - host: localhost
+    - connection_host: '{{ mysql_host }}'
     - connection_user: root
     {% if mysql_root_pass %}
     - connection_pass: '{{ mysql_root_pass }}'

--- a/mysql/remove_test_database.sls
+++ b/mysql/remove_test_database.sls
@@ -1,4 +1,5 @@
 {% set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
+{% set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost' %}
 
 include:
   - mysql.python
@@ -6,7 +7,7 @@ include:
 mysql remove test database:
   mysql_database.absent:
     - name: test
-    - host: localhost
+    - host: '{{ mysql_host }}'
     - connection_user: root
     {% if mysql_root_pass %}
     - connection_pass: '{{ mysql_root_pass }}'

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -4,6 +4,7 @@
 {% set os = salt['grains.get']('os', None) %}
 {% set os_family = salt['grains.get']('os_family', None) %}
 {% set mysql_root_password = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
+{% set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost') %}
 
 {% if mysql_root_password %}
 {% if os_family == 'Debian' %}
@@ -39,7 +40,7 @@ mysql_delete_anonymous_user_{{ host }}:
     - absent
     - host: {{ host or "''" }}
     - name: ''
-    - connection_host: localhost
+    - connection_host: '{{ mysql_host }}'
     - connection_user: root
     - connection_pass: {{ mysql_root_password }}
     - connection_charset: utf8

--- a/mysql/user.sls
+++ b/mysql/user.sls
@@ -1,6 +1,7 @@
 {% from "mysql/defaults.yaml" import rawmap with context %}
 {%- set mysql = salt['grains.filter_by'](rawmap, grain='os', merge=salt['pillar.get']('mysql:server:lookup')) %}
 {%- set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', 'somepass') %}
+{%- set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost') %}
 
 {% set user_states = [] %}
 {% set user_hosts = [] %}
@@ -31,7 +32,7 @@ include:
   {%- else %}
     - allow_passwordless: True
   {%- endif %}
-    - connection_host: localhost
+    - connection_host: '{{ mysql_host }}'
     - connection_user: root
     {% if mysql_root_pass %}
     - connection_pass: '{{ mysql_root_pass }}'
@@ -47,7 +48,7 @@ include:
     - grant_option: {{ db['grant_option'] | default(False) }}
     - user: {{ name }}
     - host: '{{ host }}'
-    - connection_host: localhost
+    - connection_host: '{{ mysql_host }}'
     - connection_user: root
     {% if mysql_root_pass -%}
     - connection_pass: '{{ mysql_root_pass }}'

--- a/pillar.example
+++ b/pillar.example
@@ -3,6 +3,9 @@ mysql:
     # root_password: False - to have root@localhost without password
     root_password: 'somepass'
     user: mysql
+    # If you only manage the dbs and users and the server is on
+    # another host
+    host: 123.123.123.123
     # my.cnf sections changes 
     mysqld:
       # you can use either underscore or hyphen in param names


### PR DESCRIPTION
In our setup we mostly use mysql on localhost but sometimes it's on another server (Amazon rds for example) and it would be nice to be able to control the users and databases using this same state instead of having to code it separately. This just adds possibility of overriding the host with pillar data and defaults lo localhost otherwise