### PR TITLE
Allow changing connection_user by setting the 'mysql:server:root_user…

### DIFF
--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -1,6 +1,7 @@
 {% from "mysql/defaults.yaml" import rawmap with context %}
 {%- set mysql = salt['grains.filter_by'](rawmap, grain='os', merge=salt['pillar.get']('mysql:lookup')) %}
 
+{% set mysql_root_user = salt['pillar.get']('mysql:server:root_user', 'root') %}
 {% set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
 {% set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost') %}
 {% set db_states = [] %}
@@ -14,7 +15,7 @@ include:
   mysql_database.present:
     - name: {{ database }}
     - connection_host: '{{ mysql_host }}'
-    - connection_user: root
+    - connection_user: '{{ mysql_root_user }}'
     {% if mysql_root_pass %}
     - connection_pass: '{{ mysql_root_pass }}'
     {% endif %}

--- a/mysql/remove_test_database.sls
+++ b/mysql/remove_test_database.sls
@@ -1,3 +1,4 @@
+{% set mysql_root_user = salt['pillar.get']('mysql:server:root_user', 'root') %}
 {% set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
 {% set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost') %}
 
@@ -8,7 +9,7 @@ mysql remove test database:
   mysql_database.absent:
     - name: test
     - host: '{{ mysql_host }}'
-    - connection_user: root
+    - connection_user: '{{ mysql_root_user }}'
     {% if mysql_root_pass %}
     - connection_pass: '{{ mysql_root_pass }}'
     {% endif %}

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -3,6 +3,7 @@
 
 {% set os = salt['grains.get']('os', None) %}
 {% set os_family = salt['grains.get']('os_family', None) %}
+{% set mysql_root_user = salt['pillar.get']('mysql:server:root_user', 'root') %}
 {% set mysql_root_password = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
 {% set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost') %}
 
@@ -41,8 +42,10 @@ mysql_delete_anonymous_user_{{ host }}:
     - host: {{ host or "''" }}
     - name: ''
     - connection_host: '{{ mysql_host }}'
-    - connection_user: root
-    - connection_pass: {{ mysql_root_password }}
+    - connection_user: '{{ mysql_root_user }}'
+    {% if mysql_root_password %}
+    - connection_pass: '{{ mysql_root_password }}'
+    {% endif %}
     - connection_charset: utf8
     - require:
       - service: mysqld

--- a/mysql/user.sls
+++ b/mysql/user.sls
@@ -1,5 +1,6 @@
 {% from "mysql/defaults.yaml" import rawmap with context %}
 {%- set mysql = salt['grains.filter_by'](rawmap, grain='os', merge=salt['pillar.get']('mysql:server:lookup')) %}
+{%- set mysql_root_user = salt['pillar.get']('mysql:server:root_user', 'root') %}
 {%- set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', 'somepass') %}
 {%- set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost') %}
 
@@ -33,7 +34,7 @@ include:
     - allow_passwordless: True
   {%- endif %}
     - connection_host: '{{ mysql_host }}'
-    - connection_user: root
+    - connection_user: '{{ mysql_root_user }}'
     {% if mysql_root_pass %}
     - connection_pass: '{{ mysql_root_pass }}'
     {% endif %}
@@ -49,7 +50,7 @@ include:
     - user: {{ name }}
     - host: '{{ host }}'
     - connection_host: '{{ mysql_host }}'
-    - connection_user: root
+    - connection_user: '{{ mysql_root_user }}'
     {% if mysql_root_pass -%}
     - connection_pass: '{{ mysql_root_pass }}'
     {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,7 @@
 mysql:
   server:
+    # Use this account for database admin (defaults to root)
+    root_user: 'admin'
     # root_password: False - to have root@localhost without password
     root_password: 'somepass'
     user: mysql


### PR DESCRIPTION
…' Pillar key

In some MySQL server configurations (e.g., Amazon RDS), the root account
may not be available.  Instead, one may need to use a different account
in order to perform database administration.  This change replaced hard-
coded references to the root account with a Pillar lookup that defaults
to 'root'.  Existing users of this formula should see no change in its
behavior.