### PR TITLE
Use default root_password if not set

### DIFF
--- a/mysql/user.sls
+++ b/mysql/user.sls
@@ -1,7 +1,7 @@
 {% from "mysql/defaults.yaml" import rawmap with context %}
 {%- set mysql = salt['grains.filter_by'](rawmap, grain='os', merge=salt['pillar.get']('mysql:server:lookup')) %}
 {%- set mysql_root_user = salt['pillar.get']('mysql:server:root_user', 'root') %}
-{%- set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', 'somepass') %}
+{%- set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
 {%- set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost') %}
 
 {% set user_states = [] %}


### PR DESCRIPTION
If no root_password pillar was set, adding users was not possible since it did not use the server_id as password