### PR TITLE
Use mysql.server variable instead of hardcoded mysql-server for debconf

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -15,11 +15,11 @@ mysql_debconf_utils:
 
 mysql_debconf:
   debconf.set:
-    - name: mysql-server
+    - name: {{ mysql.server }}
     - data:
-        'mysql-server/root_password': {'type': 'password', 'value': '{{ mysql_root_password }}'}
-        'mysql-server/root_password_again': {'type': 'password', 'value': '{{ mysql_root_password }}'}
-        'mysql-server/start_on_boot': {'type': 'boolean', 'value': 'true'}
+        '{{ mysql.server }}/root_password': {'type': 'password', 'value': '{{ mysql_root_password }}'}
+        '{{ mysql.server }}/root_password_again': {'type': 'password', 'value': '{{ mysql_root_password }}'}
+        '{{ mysql.server }}/start_on_boot': {'type': 'boolean', 'value': 'true'}
     - require_in:
       - pkg: mysqld
     - require:


### PR DESCRIPTION
The debconf functionality does not work if the mysql.server variable has been used in the pillar to change the package name.

This fix has been tested on `percona-server-server` package which is filesystem compatible with `mysql-server`.