### PR TITLE
Fix RedHat MySQL admin root username pillar setup.

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -27,8 +27,8 @@ mysql_debconf:
 {% elif os_family == 'RedHat' or 'Suse' %}
 mysql_root_password:
   cmd.run:
-    - name: mysqladmin --user root password '{{ mysql_root_password|replace("'", "'\"'\"'") }}'
-    - unless: mysql --user root --password='{{ mysql_root_password|replace("'", "'\"'\"'") }}' --execute="SELECT 1;"
+    - name: mysqladmin --user {{ mysql_root_user }} password '{{ mysql_root_password|replace("'", "'\"'\"'") }}'
+    - unless: mysql --user {{ mysql_root_user }} --password='{{ mysql_root_password|replace("'", "'\"'\"'") }}' --execute="SELECT 1;"
     - require:
       - service: mysqld
 


### PR DESCRIPTION
On RHEL, the current mysql_root_user variable is not used when configuring the MySQL server. As a result, using a username other than root causes failures of subsequent functions such as mysql_user.absent and mysql_db_*.