### PR TITLE
Fix database administrative user within database import command

### DIFF
--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -35,7 +35,7 @@ include:
 
 {{ state_id }}_load:
   cmd.wait:
-    - name: mysql -u root -p{{ mysql_root_pass }} {{ database }} < /etc/mysql/{{ database }}.schema
+    - name: mysql -u {{ mysql_root_user }} -p{{ mysql_root_pass }} {{ database }} < /etc/mysql/{{ database }}.schema
     - watch:
       - file: {{ state_id }}_schema
       - mysql_database: {{ state_id }}


### PR DESCRIPTION
Fixes issue with import of databases when using non-standard root user account.