### PR TITLE
Archlinux - create initial mysql data directory

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -57,6 +57,19 @@ mysql_delete_anonymous_user_{{ host }}:
 {% endfor %}
 {% endif %}
 
+# on arch linux: inital mysql datadirectory is not created
+{% if os_family == 'Arch' %}
+  cmd.run:
+    - name: mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
+    - user: root
+    - creates: /var/lib/mysql/mysql
+    - require:
+      - pkg: mysqld
+      - file: mysql_config
+    - require_in:
+      - service: mysqld
+{% endif %}
+
 mysqld:
   pkg.installed:
     - name: {{ mysql.server }}

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -24,14 +24,13 @@ mysql_debconf:
       - pkg: mysqld
     - require:
       - pkg: mysql_debconf_utils
-{% elif os_family == 'RedHat' or os_family == 'Suse' or os_family == 'Arch' %}
+{% elif os_family == 'RedHat' or 'Suse' %}
 mysql_root_password:
   cmd.run:
     - name: mysqladmin --user {{ mysql_root_user }} password '{{ mysql_root_password|replace("'", "'\"'\"'") }}'
     - unless: mysql --user {{ mysql_root_user }} --password='{{ mysql_root_password|replace("'", "'\"'\"'") }}' --execute="SELECT 1;"
     - require:
       - service: mysqld
-{% endif %}
 
 include:
   - mysql.python
@@ -55,6 +54,7 @@ mysql_delete_anonymous_user_{{ host }}:
       - cmd: mysql_root_password
       {%- endif %}
 {% endfor %}
+{% endif %}
 {% endif %}
 
 # on arch linux: inital mysql datadirectory is not created

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -58,16 +58,25 @@ mysql_delete_anonymous_user_{{ host }}:
 {% endif %}
 
 # on arch linux: inital mysql datadirectory is not created
+mysql_install_datadir:
 {% if os_family == 'Arch' %}
   cmd.run:
     - name: mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
     - user: root
-    - creates: /var/lib/mysql/mysql
+    - creates: /var/lib/mysql/mysql/user.frm
     - require:
       - pkg: mysqld
       - file: mysql_config
     - require_in:
       - service: mysqld
+
+mysql_create_logdir:
+  file.directory:
+    - name: /var/log/mysql
+    - user: mysql
+    - group: mysql
+    - dir_mode: 750
+
 {% endif %}
 
 mysqld:

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -69,14 +69,6 @@ mysql_install_datadir:
       - file: mysql_config
     - require_in:
       - service: mysqld
-
-mysql_create_logdir:
-  file.directory:
-    - name: /var/log/mysql
-    - user: mysql
-    - group: mysql
-    - dir_mode: 750
-
 {% endif %}
 
 mysqld:

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -24,13 +24,14 @@ mysql_debconf:
       - pkg: mysqld
     - require:
       - pkg: mysql_debconf_utils
-{% elif os_family == 'RedHat' or 'Suse' %}
+{% elif os_family == 'RedHat' or os_family == 'Suse' or os_family == 'Arch' %}
 mysql_root_password:
   cmd.run:
     - name: mysqladmin --user root password '{{ mysql_root_password|replace("'", "'\"'\"'") }}'
     - unless: mysql --user root --password='{{ mysql_root_password|replace("'", "'\"'\"'") }}' --execute="SELECT 1;"
     - require:
       - service: mysqld
+{% endif %}
 
 include:
   - mysql.python
@@ -54,7 +55,6 @@ mysql_delete_anonymous_user_{{ host }}:
       - cmd: mysql_root_password
       {%- endif %}
 {% endfor %}
-{% endif %}
 {% endif %}
 
 mysqld:


### PR DESCRIPTION
Arch linux does not automatically create the base mysql data directory structure and table. This patch calls mysql_install_db script to create it.