### PR TITLE
Fix empty "mysql_install_datadir" dict when OS family is not "Arch"

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -57,9 +57,9 @@ mysql_delete_anonymous_user_{{ host }}:
 {% endif %}
 {% endif %}
 
+{% if os_family == 'Arch' %}
 # on arch linux: inital mysql datadirectory is not created
 mysql_install_datadir:
-{% if os_family == 'Arch' %}
   cmd.run:
     - name: mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
     - user: root


### PR DESCRIPTION
When OS family is other than "Arch" mysql_install_datadir will be a empty dictionary. Related with PR merge: d6a4a1a21474570e1837924c7e46b1b5d63afff3