### PR TITLE
Add states for optional dedicated salt user instead of root.

### DIFF
--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -6,6 +6,9 @@
 {% set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost') %}
 {% set db_states = [] %}
 
+{% set mysql_salt_user = salt['pillar.get']('mysql:salt_user:salt_user_name', mysql_root_user) %}
+{% set mysql_salt_password = salt['pillar.get']('mysql:salt_user:salt_user_password', mysql_root_password) %}
+
 include:
   - mysql.python
 
@@ -15,9 +18,9 @@ include:
   mysql_database.present:
     - name: {{ database }}
     - connection_host: '{{ mysql_host }}'
-    - connection_user: '{{ mysql_root_user }}'
-    {% if mysql_root_pass %}
-    - connection_pass: '{{ mysql_root_pass }}'
+    - connection_user: '{{ mysql_salt_user }}'
+    {% if mysql_salt_pass %}
+    - connection_pass: '{{ mysql_salt_pass }}'
     {% endif %}
     - connection_charset: utf8
 
@@ -35,7 +38,7 @@ include:
 
 {{ state_id }}_load:
   cmd.wait:
-    - name: mysql -u {{ mysql_root_user }} -p{{ mysql_root_pass }} {{ database }} < /etc/mysql/{{ database }}.schema
+    - name: mysql -u {{ mysql_salt_user }} -p{{ mysql_salt_pass }} {{ database }} < /etc/mysql/{{ database }}.schema
     - watch:
       - file: {{ state_id }}_schema
       - mysql_database: {{ state_id }}

--- a/mysql/remove_test_database.sls
+++ b/mysql/remove_test_database.sls
@@ -1,6 +1,8 @@
 {% set mysql_root_user = salt['pillar.get']('mysql:server:root_user', 'root') %}
 {% set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
 {% set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost') %}
+{% set mysql_salt_user = salt['pillar.get']('mysql:salt_user:salt_user_name', mysql_root_user) %}
+{% set mysql_salt_password = salt['pillar.get']('mysql:salt_user:salt_user_password', mysql_root_password) %}
 
 include:
   - mysql.python
@@ -9,8 +11,8 @@ mysql remove test database:
   mysql_database.absent:
     - name: test
     - host: '{{ mysql_host }}'
-    - connection_user: '{{ mysql_root_user }}'
-    {% if mysql_root_pass %}
-    - connection_pass: '{{ mysql_root_pass }}'
+    - connection_user: '{{ mysql_salt_user }}'
+    {% if mysql_salt_pass %}
+    - connection_pass: '{{ mysql_salt_pass }}'
     {% endif %}
     - connection_charset: utf8

--- a/mysql/salt-user.sls
+++ b/mysql/salt-user.sls
@@ -1,0 +1,148 @@
+include:
+  - mysql.server
+
+{% set os_family = salt['grains.get']('os_family', None) %}
+{% set mysql_salt_user = salt['pillar.get']('mysql:salt_user:salt_user_name', 'salt') %}
+{% set mysql_salt_pass = salt['pillar.get']('mysql:salt_user:salt_user_password', salt['grains.get']('server_id')) %}
+{% set mysql_salt_grants = salt['pillar.get']('mysql:salt_user:grants', []) %}
+{% set mysql_root_user = salt['pillar.get']('mysql:server:root_user', 'root') %}
+{% set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
+{% set mysql_root_hash = salt['pillar.get']('mysql:server:root_password_hash', None) %}
+
+{% set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost') %}
+{% if mysql_host == 'localhost' %}
+{% set host = 'localhost' %}
+{% else %}
+{% set host = grains['fqdn'] %}
+{% endif %}
+
+mysql_salt_user_with_salt_user:
+  mysql_user.present:
+    - name: {{ mysql_salt_user }}
+    - host: '{{ host }}'
+    - password: '{{ mysql_salt_pass }}'
+    - connection_host: '{{ mysql_host }}'
+    - connection_user: '{{ mysql_salt_user }}'
+    - connection_pass: '{{ mysql_salt_pass }}'
+    - connection_charset: utf8
+    - onlyif:
+      - mysql --user {{ mysql_salt_user }} --password='{{ mysql_salt_pass|replace("'", "'\"'\"'") }}' -h {{ mysql_host }} --execute="SELECT 1;"
+      - VALUE=$(mysql --user {{ mysql_salt_user }} --password='{{ mysql_salt_pass|replace("'", "'\"'\"'") }}' -ss -e "SELECT Grant_priv FROM mysql.user WHERE user = '{{ mysql_salt_user }}' AND host = '{{ host }}';"); if [ "$VALUE" = 'Y' ]; then /bin/true; else /bin/false; fi
+    - require_in:
+      - mysql_user: mysql_root_password
+
+{%- if mysql_salt_grants != [] %}
+mysql_salt_user_with_salt_user_grants:
+  mysql_grants.present:
+    - name: {{ mysql_salt_user }}
+    - grant: {{ mysql_salt_grants|join(",") }}
+    - database: '*.*'
+    - grant_option: True
+    - user: {{ mysql_salt_user }}
+    - host: '{{ host }}'
+    - connection_host: '{{ mysql_host }}'
+    - connection_user: '{{ mysql_salt_user }}'
+    - connection_pass: '{{ mysql_salt_pass }}'
+    - connection_charset: utf8
+    - onlyif:
+      - mysql --user {{ mysql_salt_user }} --password='{{ mysql_salt_pass|replace("'", "'\"'\"'") }}' -h {{ mysql_host }} --execute="SELECT 1;"
+      - VALUE=$(mysql --user {{ mysql_salt_user }} --password='{{ mysql_salt_pass|replace("'", "'\"'\"'") }}' -ss -e "SELECT Grant_priv FROM mysql.user WHERE user = '{{ mysql_salt_user }}' AND host = '{{ host }}';"); if [ "$VALUE" = 'Y' ]; then /bin/true; else /bin/false; fi
+    - require:
+      - mysql_user: mysql_salt_user_with_salt_user
+    - require_in:
+      - mysql_user: mysql_root_password
+{% endif %}
+
+mysql_salt_user_with_root_user:
+  mysql_user.present:
+    - name: {{ mysql_salt_user }}
+    - host: '{{ host }}'
+    - password: '{{ mysql_salt_pass }}'
+    - connection_host: '{{ mysql_host }}'
+    - connection_user: '{{ mysql_root_user }}'
+    - connection_pass: '{{ mysql_root_pass }}'
+    - connection_charset: utf8
+    - onlyif:
+      - mysql --user {{ mysql_root_user }} --password='{{ mysql_root_pass|replace("'", "'\"'\"'") }}' -h {{ mysql_host }} --execute="SELECT 1;"
+      - VALUE=$(mysql --user {{ mysql_root_user }} --password='{{ mysql_root_pass|replace("'", "'\"'\"'") }}' -ss -e "SELECT Grant_priv FROM mysql.user WHERE user = '{{ mysql_salt_user }}' AND host = '{{ host }}';"); if [ "$VALUE" = 'N' -o -z "$VALUE" ]; then /bin/true; else /bin/false; fi
+    - require_in:
+      - mysql_user: mysql_root_password
+
+{%- if mysql_salt_grants != [] %}
+mysql_salt_user_with_root_user_grants:
+  mysql_grants.present:
+    - name: {{ mysql_salt_user }}
+    - grant: {{ mysql_salt_grants|join(",") }}
+    - database: '*.*'
+    - grant_option: True
+    - user: {{ mysql_salt_user }}
+    - host: '{{ host }}'
+    - connection_host: '{{ mysql_host }}'
+    - connection_user: '{{ mysql_root_user }}'
+    - connection_pass: '{{ mysql_root_pass }}'
+    - connection_charset: utf8
+    - onlyif:
+      - mysql --user {{ mysql_root_user }} --password='{{ mysql_root_pass|replace("'", "'\"'\"'") }}' -h {{ mysql_host }} --execute="SELECT 1;"
+      - VALUE=$(mysql --user {{ mysql_root_user }} --password='{{ mysql_root_pass|replace("'", "'\"'\"'") }}' -ss -e "SELECT Grant_priv FROM mysql.user WHERE user = '{{ mysql_salt_user }}' AND host = '{{ host }}';"); if [ "$VALUE" = 'N' -o -z "$VALUE" ]; then /bin/true; else /bin/false; fi
+    - require:
+      - mysql_user: mysql_salt_user_with_root_user
+    - require_in:
+      - mysql_user: mysql_root_password
+{% endif %}
+
+mysql_salt_user_with_passwordless_root_user:
+  mysql_user.present:
+    - name: {{ mysql_salt_user }}
+    - host: '{{ host }}'
+    - password: '{{ mysql_salt_pass }}'
+    - connection_host: '{{ mysql_host }}'
+    - connection_user: '{{ mysql_root_user }}'
+    - connection_charset: utf8
+    - onlyif:
+      - mysql --user {{ mysql_root_user }} -h {{ mysql_host }} --execute="SELECT 1;"
+      - VALUE=$(mysql --user {{ mysql_root_user }} -ss -e "SELECT Grant_priv FROM mysql.user WHERE user = '{{ mysql_salt_user }}' AND host = '{{ host }}';"); if [ "$VALUE" = 'N' -o -z "$VALUE" ]; then /bin/true; else /bin/false; fi
+    - require_in:
+      - mysql_user: mysql_root_password
+
+{%- if mysql_salt_grants != [] %}
+mysql_salt_user_with_passwordless_root_user_grants:
+  mysql_grants.present:
+    - name: {{ mysql_salt_user }}
+    - grant: {{ mysql_salt_grants|join(",") }}
+    - database: '*.*'
+    - grant_option: True
+    - user: {{ mysql_salt_user }}
+    - host: '{{ host }}'
+    - connection_host: '{{ mysql_host }}'
+    - connection_user: '{{ mysql_root_user }}'
+    - connection_charset: utf8
+    - onlyif:
+      - mysql --user {{ mysql_root_user }} -h {{ mysql_host }} --execute="SELECT 1;"
+      - VALUE=$(mysql --user {{ mysql_root_user }} -ss -e "SELECT Grant_priv FROM mysql.user WHERE user = '{{ mysql_salt_user }}' AND host = '{{ host }}';"); if [ "$VALUE" = 'N' -o -z "$VALUE" ]; then /bin/true; else /bin/false; fi
+    - require:
+      - mysql_user: mysql_salt_user_with_passwordless_root_user
+    - require_in:
+      - mysql_user: mysql_root_password
+{% endif %}
+
+{% if os_family == 'RedHat' or 'Suse' %}
+extend:
+  mysql_root_password:
+    cmd.run:
+      - name: /bin/true
+      - unless: /bin/true
+    mysql_user.present:
+      - name: {{ mysql_root_user }}
+      - host: 'localhost'
+      {%- if mysql_root_hash != None %}
+      - password_hash: '{{ mysql_root_hash }}'
+      {%- elif mysql_root_pass != None %}
+      - password: '{{ mysql_root_pass }}'
+      {%- else %}
+      - allow_passwordless: True
+      {%- endif %}
+      - connection_host: '{{ mysql_host }}'
+      - connection_user: '{{ mysql_salt_user }}'
+      - connection_pass: '{{ mysql_salt_pass }}'
+      - connection_charset: utf8
+{% endif %}

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -6,6 +6,8 @@
 {% set mysql_root_user = salt['pillar.get']('mysql:server:root_user', 'root') %}
 {% set mysql_root_password = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
 {% set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost') %}
+{% set mysql_salt_user = salt['pillar.get']('mysql:salt_user:salt_user_name', mysql_root_user) %}
+{% set mysql_salt_password = salt['pillar.get']('mysql:salt_user:salt_user_password', mysql_root_password) %}
 
 {% if mysql_root_password %}
 {% if os_family == 'Debian' %}
@@ -42,15 +44,15 @@ mysql_delete_anonymous_user_{{ host }}:
     - host: {{ host or "''" }}
     - name: ''
     - connection_host: '{{ mysql_host }}'
-    - connection_user: '{{ mysql_root_user }}'
-    {% if mysql_root_password %}
-    - connection_pass: '{{ mysql_root_password }}'
+    - connection_user: '{{ mysql_salt_user }}'
+    {% if mysql_salt_password %}
+    - connection_pass: '{{ mysql_salt_password }}'
     {% endif %}
     - connection_charset: utf8
     - require:
       - service: mysqld
       - pkg: mysql_python
-      {%- if mysql_root_password %}
+      {%- if (mysql_salt_user == mysql_root_user) and mysql_root_password %}
       - cmd: mysql_root_password
       {%- endif %}
 {% endfor %}

--- a/mysql/user.sls
+++ b/mysql/user.sls
@@ -3,6 +3,8 @@
 {%- set mysql_root_user = salt['pillar.get']('mysql:server:root_user', 'root') %}
 {%- set mysql_root_pass = salt['pillar.get']('mysql:server:root_password', salt['grains.get']('server_id')) %}
 {%- set mysql_host = salt['pillar.get']('mysql:server:host', 'localhost') %}
+{% set mysql_salt_user = salt['pillar.get']('mysql:salt_user:salt_user_name', mysql_root_user) %}
+{% set mysql_salt_password = salt['pillar.get']('mysql:salt_user:salt_user_password', mysql_root_password) %}
 
 {% set user_states = [] %}
 {% set user_hosts = [] %}
@@ -34,9 +36,9 @@ include:
     - allow_passwordless: True
   {%- endif %}
     - connection_host: '{{ mysql_host }}'
-    - connection_user: '{{ mysql_root_user }}'
-    {% if mysql_root_pass %}
-    - connection_pass: '{{ mysql_root_pass }}'
+    - connection_user: '{{ mysql_salt_user }}'
+    {% if mysql_salt_pass %}
+    - connection_pass: '{{ mysql_salt_pass }}'
     {% endif %}
     - connection_charset: utf8
 
@@ -50,9 +52,9 @@ include:
     - user: {{ name }}
     - host: '{{ host }}'
     - connection_host: localhost
-    - connection_user: root
-    {% if mysql_root_pass -%}
-    - connection_pass: '{{ mysql_root_pass }}'
+    - connection_user: '{{ mysql_salt_user }}'
+    {% if mysql_salt_pass -%}
+    - connection_pass: '{{ mysql_salt_pass }}'
     {% endif %}
     - connection_charset: utf8
     - require:
@@ -70,9 +72,9 @@ include:
     - user: {{ name }}
     - host: '{{ host }}'
     - connection_host: '{{ mysql_host }}'
-    - connection_user: '{{ mysql_root_user }}'
-    {% if mysql_root_pass -%}
-    - connection_pass: '{{ mysql_root_pass }}'
+    - connection_user: '{{ mysql_salt_user }}'
+    {% if mysql_salt_pass -%}
+    - connection_pass: '{{ mysql_salt_pass }}'
     {% endif %}
     - connection_charset: utf8
     - require:

--- a/pillar.example
+++ b/pillar.example
@@ -4,6 +4,7 @@ mysql:
     root_user: 'admin'
     # root_password: '' - to have root@localhost without password
     root_password: 'somepass'
+    root_password_hash: '*13883BDDBE566ECECC0501CDE9B293303116521A'
     user: mysql
     # If you only manage the dbs and users and the server is on
     # another host
@@ -19,6 +20,12 @@ mysql:
     mysql:
       # my.cnf param that not require value
       no-auto-rehash: noarg_present
+
+  salt_user:
+    salt_user_name: 'salt'
+    salt_user_password: 'someotherpass'
+    grants:
+      - 'all privileges'
 
   # Manage databases
   database:


### PR DESCRIPTION
Some use cases for this are
* no need to have the root password in plain text in pillar (we can use a hash instead)
* useful for auditing when you can distinguish between salt accesses and actual root accesses

The main tricky thing here is how to make it work in the most common scenarios, like:
* an existing setup using root with password defined in pillar
* a fresh setup using root without any password
* an existing setup using root without password (e.g. with socket authentication)
* a second-run setup already using the salt user and only having a password hash for root
* a setup that keeps on using root instead of the salt user

I tried to cover as much ground as possible here, but I'm not entirely sure I got the service dependencies right. Especially the deletion of the anonymous users is difficult to make work with an optional salt user.

An additional limitation is that for Debian based systems you'd still need the root password in plain text, because of the use of debconf. That would need to be adjusted (if wanted) by someone who actually knows things about Debian.

Feedback appreciated :)