### PR TITLE
Allow loading into remote databases

### DIFF
--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -38,7 +38,7 @@ include:
 
 {{ state_id }}_load:
   cmd.wait:
-    - name: mysql -u {{ mysql_salt_user }} -p{{ mysql_salt_pass }} {{ database }} < /etc/mysql/{{ database }}.schema
+    - name: mysql -u {{ mysql_salt_user }} -h{{ mysql_host }} -p{{ mysql_salt_pass }} {{ database }} < /etc/mysql/{{ database }}.schema
     - watch:
       - file: {{ state_id }}_schema
       - mysql_database: {{ state_id }}


### PR DESCRIPTION
Current databases state allows databases to be created on remote servers, but won't load schemas. Added hostname option to load state to handle.