### PR TITLE
Update server.cnf

### DIFF
--- a/mysql/files/server.cnf
+++ b/mysql/files/server.cnf
@@ -30,6 +30,8 @@
 {%- set indents = 40 - mparam|count %}
 {% if mvalue == "noarg_present" -%}
 {{ mparam }}
+{% elif mvalue == "SETONPLEASE"  %}
+{{ mparam }}{{ '='|indent(indents, true) }} ON
 {%- else -%}
 {{ mparam }}{{ '='|indent(indents, true) }} {{ mvalue }}
 {%- endif -%}


### PR DESCRIPTION
MySQL configuration file may contain `ON` values, which are being converted to `True` when executing Salt Formula, for example (event_scheduler= ON).
I made the changes to replace the value `SETONPLEASE` by `ON` 