### PR TITLE
Add support for fetching user hosts from salt mine.

### DIFF
--- a/mysql/user.sls
+++ b/mysql/user.sls
@@ -21,6 +21,16 @@ include:
   {% set user_hosts = salt['pillar.get']('mysql:user:%s:hosts'|format(name)) %}
 {% endif %}
 
+{% if not user_hosts %}
+  {% set mine_target = salt['pillar.get']('mysql:user:%s:mine_hosts:target'|format(name)) %}
+  {% set mine_function = salt['pillar.get']('mysql:user:%s:mine_hosts:function'|format(name)) %}
+  {% set mine_expression_form = salt['pillar.get']('mysql:user:%s:mine_hosts:expr_form'|format(name)) %}
+
+  {% if mine_target and mine_function and mine_expression_form %}
+    {% set user_hosts = salt['mine.get'](mine_target, mine_function, mine_expression_form).values() %}
+  {% endif %}
+{% endif %}
+
 {% for host in user_hosts %}
 
 {% set state_id = 'mysql_user_' ~ name ~ '_' ~ host%}

--- a/pillar.example
+++ b/pillar.example
@@ -81,6 +81,15 @@ mysql:
       password: ~
       host: localhost
       databases: []
+    application:
+      password: 'somepass'
+      mine_hosts:
+        target: "G@role:database and *.example.com"
+        function: "network.get_hostname"
+        expr_form: compound
+      databases:
+        - database: foo
+          grants: ['select', 'insert', 'update']
 
   # Override any names defined in map.jinja
   lookup:


### PR DESCRIPTION
This allows for more dynamically defining which database hosts a user should be added to, so you don't have to update the pillar data every time you add a new db server to your application setup.