### PR TITLE
fixed /etc/mysql/my.cnf creation failure in debian

### DIFF
--- a/mysql/config.sls
+++ b/mysql/config.sls
@@ -57,6 +57,8 @@ mysql_clients_config:
 mysql_config:
   file.managed:
     - name: {{ mysql.config.file }}
+    - require:
+      - pkg: {{ mysql.server }}
     - template: jinja
 {% if "config_directory" in mysql %}
     - source: salt://mysql/files/my-include.cnf

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -27,7 +27,7 @@ mysql_debconf:
         '{{ mysql.server }}/root_password_again': {'type': 'password', 'value': '{{ mysql_root_password }}'}
         '{{ mysql.server }}/start_on_boot': {'type': 'boolean', 'value': 'true'}
     - require_in:
-      - pkg: mysqld
+      - pkg: {{ mysql.server }}
     - require:
       - pkg: mysql_debconf_utils
 {% elif os_family == 'RedHat' or 'Suse' %}
@@ -74,18 +74,22 @@ mysql_install_datadir:
       - service: mysqld
 {% endif %}
 
-mysqld:
+mysqld-packages:
   pkg.installed:
     - name: {{ mysql.server }}
 {% if os_family == 'Debian' and mysql_root_password %}
     - require:
       - debconf: mysql_debconf
 {% endif %}
+
+mysqld:
   service.running:
     - name: {{ mysql.service }}
     - enable: True
+    - require:
+      - pkg: {{ mysql.server }}
     - watch:
-      - pkg: mysqld
+      - pkg: {{ mysql.server }}
       - file: mysql_config
 {% if "config_directory" in mysql and "server_config" in mysql %}
       - file: mysql_server_config


### PR DESCRIPTION
the config file update depends on the parent directory /etc/mysql being present, which is created as part of the mysql-server package installation. therefore, the mysqld state is split up for debian environments into the package installation and the mysqld configuration. this allows to set the pkg installation as a requirement for the config file management and to set the config file management as a requirement for the mysqld service management