### PR TITLE
fix archlinux package

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -68,7 +68,7 @@ mysql_install_datadir:
     - user: root
     - creates: /var/lib/mysql/mysql/user.frm
     - require:
-      - pkg: mysqld
+      - pkg: {{ mysql.server }} 
       - file: mysql_config
     - require_in:
       - service: mysqld


### PR DESCRIPTION
A small fix in server.sls with archlinux not using the right required package name.