### PR TITLE
Fixed formula on Debian where mysql_root_password state is not present. 

### DIFF
--- a/mysql/salt-user.sls
+++ b/mysql/salt-user.sls
@@ -28,8 +28,10 @@ mysql_salt_user_with_salt_user:
     - onlyif:
       - mysql --user {{ mysql_salt_user }} --password='{{ mysql_salt_pass|replace("'", "'\"'\"'") }}' -h {{ mysql_host }} --execute="SELECT 1;"
       - VALUE=$(mysql --user {{ mysql_salt_user }} --password='{{ mysql_salt_pass|replace("'", "'\"'\"'") }}' -ss -e "SELECT Grant_priv FROM mysql.user WHERE user = '{{ mysql_salt_user }}' AND host = '{{ host }}';"); if [ "$VALUE" = 'Y' ]; then /bin/true; else /bin/false; fi
+{% if os_family in ['RedHat', 'Suse'] %}
     - require_in:
       - mysql_user: mysql_root_password
+{% endif %}
 
 {%- if mysql_salt_grants != [] %}
 mysql_salt_user_with_salt_user_grants:
@@ -49,8 +51,10 @@ mysql_salt_user_with_salt_user_grants:
       - VALUE=$(mysql --user {{ mysql_salt_user }} --password='{{ mysql_salt_pass|replace("'", "'\"'\"'") }}' -ss -e "SELECT Grant_priv FROM mysql.user WHERE user = '{{ mysql_salt_user }}' AND host = '{{ host }}';"); if [ "$VALUE" = 'Y' ]; then /bin/true; else /bin/false; fi
     - require:
       - mysql_user: mysql_salt_user_with_salt_user
+{% if os_family in ['RedHat', 'Suse'] %}
     - require_in:
       - mysql_user: mysql_root_password
+{% endif %}
 {% endif %}
 
 mysql_salt_user_with_root_user:
@@ -65,8 +69,10 @@ mysql_salt_user_with_root_user:
     - onlyif:
       - mysql --user {{ mysql_root_user }} --password='{{ mysql_root_pass|replace("'", "'\"'\"'") }}' -h {{ mysql_host }} --execute="SELECT 1;"
       - VALUE=$(mysql --user {{ mysql_root_user }} --password='{{ mysql_root_pass|replace("'", "'\"'\"'") }}' -ss -e "SELECT Grant_priv FROM mysql.user WHERE user = '{{ mysql_salt_user }}' AND host = '{{ host }}';"); if [ "$VALUE" = 'N' -o -z "$VALUE" ]; then /bin/true; else /bin/false; fi
+{% if os_family in ['RedHat', 'Suse'] %}
     - require_in:
       - mysql_user: mysql_root_password
+{% endif %}
 
 {%- if mysql_salt_grants != [] %}
 mysql_salt_user_with_root_user_grants:
@@ -86,8 +92,10 @@ mysql_salt_user_with_root_user_grants:
       - VALUE=$(mysql --user {{ mysql_root_user }} --password='{{ mysql_root_pass|replace("'", "'\"'\"'") }}' -ss -e "SELECT Grant_priv FROM mysql.user WHERE user = '{{ mysql_salt_user }}' AND host = '{{ host }}';"); if [ "$VALUE" = 'N' -o -z "$VALUE" ]; then /bin/true; else /bin/false; fi
     - require:
       - mysql_user: mysql_salt_user_with_root_user
+{% if os_family in ['RedHat', 'Suse'] %}
     - require_in:
       - mysql_user: mysql_root_password
+{% endif %}
 {% endif %}
 
 mysql_salt_user_with_passwordless_root_user:
@@ -101,8 +109,10 @@ mysql_salt_user_with_passwordless_root_user:
     - onlyif:
       - mysql --user {{ mysql_root_user }} -h {{ mysql_host }} --execute="SELECT 1;"
       - VALUE=$(mysql --user {{ mysql_root_user }} -ss -e "SELECT Grant_priv FROM mysql.user WHERE user = '{{ mysql_salt_user }}' AND host = '{{ host }}';"); if [ "$VALUE" = 'N' -o -z "$VALUE" ]; then /bin/true; else /bin/false; fi
+{% if os_family in ['RedHat', 'Suse'] %}
     - require_in:
       - mysql_user: mysql_root_password
+{% endif %}
 
 {%- if mysql_salt_grants != [] %}
 mysql_salt_user_with_passwordless_root_user_grants:
@@ -121,11 +131,13 @@ mysql_salt_user_with_passwordless_root_user_grants:
       - VALUE=$(mysql --user {{ mysql_root_user }} -ss -e "SELECT Grant_priv FROM mysql.user WHERE user = '{{ mysql_salt_user }}' AND host = '{{ host }}';"); if [ "$VALUE" = 'N' -o -z "$VALUE" ]; then /bin/true; else /bin/false; fi
     - require:
       - mysql_user: mysql_salt_user_with_passwordless_root_user
+{% if os_family in ['RedHat', 'Suse'] %}
     - require_in:
       - mysql_user: mysql_root_password
 {% endif %}
+{% endif %}
 
-{% if os_family == 'RedHat' or 'Suse' %}
+{% if os_family in ['RedHat', 'Suse'] %}
 extend:
   mysql_root_password:
     cmd.run:

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -30,7 +30,7 @@ mysql_debconf:
       - pkg: {{ mysql.server }}
     - require:
       - pkg: mysql_debconf_utils
-{% if os_family in ['RedHat', 'Suse'] %}
+{% elif os_family in ['RedHat', 'Suse'] %}
 mysql_root_password:
   cmd.run:
     - name: mysqladmin --user {{ mysql_root_user }} password '{{ mysql_root_password|replace("'", "'\"'\"'") }}'

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -30,7 +30,7 @@ mysql_debconf:
       - pkg: {{ mysql.server }}
     - require:
       - pkg: mysql_debconf_utils
-{% elif os_family == 'RedHat' or 'Suse' %}
+{% if os_family in ['RedHat', 'Suse'] %}
 mysql_root_password:
   cmd.run:
     - name: mysqladmin --user {{ mysql_root_user }} password '{{ mysql_root_password|replace("'", "'\"'\"'") }}'


### PR DESCRIPTION
The formula failed with `Cannot extend ID 'mysql_root_password' in 'base:mysql.salt-user'.`. It was caused by `require_in` definitions in the `salt-user` state using `mysql_user: mysql_root_password`. That state is only defined in `server.sls` for RHEL & Suse (https://github.com/saltstack-formulas/mysql-formula/blob/master/mysql/server.sls#L34). The state was missing on debian, thus raising the exception. 

The PR is practically wrapping all of those with conditionals. 