### PR TITLE
This default is not overridden properly for some reason

### DIFF
--- a/mysql/defaults.yaml
+++ b/mysql/defaults.yaml
@@ -135,7 +135,7 @@ Fedora:
   server: mariadb-server
   client: mariadb
   service: mariadb
-  python: MySQL-python
+  python: python2-mysql
   config:
     file: /etc/my.cnf.d/server.cnf
     sections:


### PR DESCRIPTION
I was playing with this on Fedora 23, and the package that is installed by default no longer exists.

I haven't looked into why my override wasn't working as intended yet though.