### PR TITLE
galera: fix invalid default

### DIFF
--- a/mysql/defaults.yaml
+++ b/mysql/defaults.yaml
@@ -172,7 +172,6 @@ Fedora:
         wsrep_auto_increment_control: 1
         wsrep_drupal_282555_workaround: 0
         wsrep_causal_reads: 0
-        wsrep_notify_cmd: noarg_present
         wsrep_sst_method: rsync
         wsrep_sst_auth: "root:"
 


### PR DESCRIPTION
wsrep_notify_cmd cannot be without a value