### PR TITLE
Set environment temp directory to /tmp

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -67,6 +67,8 @@ mysql_install_datadir:
     - name: mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
     - user: root
     - creates: /var/lib/mysql/mysql/user.frm
+    - env:
+        - TMPDIR: '/tmp'
     - require:
       - pkg: {{ mysql.server }} 
       - file: mysql_config


### PR DESCRIPTION
Some distros set the environment variable for the temp directory to
/tmp/$USER which is owned by $USER mode 700. This prevents the
mysql user from being able to access the temporary files it needs.