### PR TITLE
Fix broken GRANT when not ssl

### DIFF
--- a/mysql/user.sls
+++ b/mysql/user.sls
@@ -79,6 +79,7 @@ include:
     - grant: {{db['grants']|join(",")}}
     - database: '{{ db['database'] }}.{{ db['table'] | default('*') }}'
     - grant_option: {{ db['grant_option'] | default(False) }}
+    {% if 'ssl' in user or 'ssl-X509' in user %}
     - ssl_option:
       - SSL: {{ user['ssl'] | default(False) }}
     {% if user['ssl-X509'] is defined %}
@@ -92,6 +93,7 @@ include:
     {% endif %}
     {% if user['ssl-CIPHER'] is defined %}
       - CIPHER: {{ user['ssl-CIPHER'] }}
+    {% endif %}
     {% endif %}
     - user: {{ name }}
     - host: '{{ host }}'


### PR DESCRIPTION
if ssl_option is not False, mysql_grant.present adds "REQUIRE" to the
grant command but since all the ssl sub options are false or missing,
there is a null string appended to the requirements. This causes the
grant command to fail.

This tests to see if ssl or X509 are set. If they're not, it skips the
entire ssl_option section leaving ssl_option==False to prevent that
error.

Fixes #131 