### PR TITLE
Feature setting the template context from the mysql:schema pillar

### DIFF
--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -30,8 +30,10 @@ include:
     - name: /etc/mysql/{{ database }}.schema
     - source: {{ salt['pillar.get'](['mysql', 'schema', database, 'source']|join(':')) }}
 {%- set template_type = salt['pillar.get'](['mysql', 'schema', database, 'template']|join(':'), False) %}
+{%- set template_context = salt['pillar.get'](['mysql', 'schema', database, 'context']|join(':'), {}) %}
 {%- if template_type %}
     - template: {{ template_type }}
+    - context: {{ template_context|yaml }}
 {% endif %}
     - user: {{ salt['pillar.get']('mysql:server:user', 'mysql') }}
     - makedirs: True

--- a/pillar.example
+++ b/pillar.example
@@ -55,6 +55,20 @@ mysql:
       load: True
       source: salt://mysql/files/baz.schema.tmpl
       template: jinja
+    qux:
+      load: True
+      source: salt://mysql/files/qux.schema.tmpl
+      template: jinja
+      context:
+        encabulator: Turbo
+        girdlespring: differential
+    quux:
+      load: True
+      source: salt://mysql/files/qux.schema.tmpl
+      template: jinja
+      context:
+        encabulator: Retro
+        girdlespring: integral
 
   # Manage users
   # you can get pillar for existing server using scripts/import_users.py script


### PR DESCRIPTION
This simplifies how schema files can be templated, especially when using
the same template to set up multiple databases on the same server.