### PR TITLE
Adjust check to mysql.version due to compile fail on Arch.

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -64,7 +64,7 @@ mysql_delete_anonymous_user_{{ host }}:
 # on arch linux: inital mysql datadirectory is not created
 mysql_install_datadir:
   cmd.run:
-{% if pkg.version >= 5.7 %}
+{% if mysql.version >= 5.7 %}
     - name: mysqld --initialize-insecure --user=mysql --basedir=/usr --datadir=/var/lib/mysql
 {% else %}
     - name: mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
@@ -88,7 +88,7 @@ mysqld-packages:
       - debconf: mysql_debconf
 {% endif %}
 
-{% if os_family == 'RedHat' or 'Suse' and pkg.version >= 5.7 %}
+{% if os_family == 'RedHat' or 'Suse' and mysql.version >= 5.7 %}
 # Initialize mysql database with --initialize-insecure option before starting service so we don't get locked out.
 mysql_initialize:
   cmd.run:
@@ -105,7 +105,7 @@ mysqld:
     - enable: True
     - require:
       - pkg: {{ mysql.server }}
-{% if os_family == 'RedHat' or 'Suse' and pkg.version >= 5.7 %}
+{% if os_family == 'RedHat' or 'Suse' and mysql.version >= 5.7 %}
       - cmd: mysql_initialize
 {% endif %}
     - watch:


### PR DESCRIPTION
@aboe76 noted a compile error on Arch using pkg.version as the check for 5.7+. His recommendation was to adjust it to mysql.version as this works on Arch.

Tested on Redhat and solution still works with this check.