### PR TITLE
Add official repo state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,3 +96,13 @@ Install the MySQL development libraries and header files.
     Note that this state is not installed by the mysql meta-state unless you set
     your pillar data accordingly.
 
+``mysql.repo``
+--------------
+
+Add the official MySQL 5.7 repository.
+
+.. note::
+    Note that this state currently only supports MySQL 5.7 for RHEL systems.
+    Debian and Suse support to be added. Also need to add the option to allow
+    selection of MySQL version (5.6 and 5.5 repos are added but disabled) and
+    changed enabled repository accordingly.

--- a/mysql/repo.sls
+++ b/mysql/repo.sls
@@ -1,0 +1,65 @@
+include:
+  - mysql.config
+
+{% from "mysql/defaults.yaml" import rawmap with context %}
+{%- set mysql = salt['grains.filter_by'](rawmap, grain='os', merge=salt['pillar.get']('mysql:lookup')) %}
+
+# Completely ignore non-RHEL based systems
+# TODO: Add Debian and Suse systems.
+# TODO: Allow user to specify MySQL version and alter yum repo file accordingly.
+{% if grains['os_family'] == 'RedHat' %}
+  {% if grains['osmajorrelease'][0] == '5' %}
+  {% set rpm_source = "http://repo.mysql.com/mysql57-community-release-el5.rpm" %}
+  {% elif grains['osmajorrelease'][0] == '6' %}
+  {% set rpm_source = "http://repo.mysql.com/mysql57-community-release-el6.rpm" %}
+  {% elif grains['osmajorrelease'][0] == '7' %}
+  {% set rpm_source = "http://repo.mysql.com/mysql57-community-release-el7.rpm" %}
+  {% endif %}
+{% endif %}
+
+{% set mysql57_community_release = salt['pillar.get']('mysql:release', false) %}
+# A lookup table for MySQL Repo GPG keys & RPM URLs for various RedHat releases
+  {% set pkg = {
+    'key': 'http://repo.mysql.com/RPM-GPG-KEY-mysql',
+    'key_hash': 'md5=e9efdf96207c90f4487462cd1f3ff764',
+    'rpm': rpm_source
+ } %}
+
+
+install_pubkey_mysql:
+  file.managed:
+    - name: /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
+    - source: {{ salt['pillar.get']('mysql:pubkey', pkg.key) }}
+    - source_hash:  {{ salt['pillar.get']('mysql:pubkey_hash', pkg.key_hash) }}
+
+mysql57_community_release:
+  pkg.installed:
+    - sources:
+      - mysql57-community-release: {{ salt['pillar.get']('mysql:repo_rpm', pkg.rpm) }}
+    - require:
+      - file: install_pubkey_mysql
+    - require_in:
+      {% if "server_config" in mysql %}
+      - pkg: {{ mysql.server }}
+      {% endif %}
+      {% if "clients_config" in mysql %}
+      - pkg: {{ mysql.client }}
+      {% endif %}
+
+set_pubkey_mysql:
+  file.replace:
+    - append_if_not_found: True
+    - name: /etc/yum.repos.d/mysql-community.repo
+    - pattern: '^gpgkey=.*'
+    - repl: 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql'
+    - require:
+      - pkg: mysql57_community_release
+
+set_gpg_mysql:
+  file.replace:
+    - append_if_not_found: True
+    - name: /etc/yum.repos.d/mysql-community.repo
+    - pattern: 'gpgcheck=.*'
+    - repl: 'gpgcheck=1'
+    - require:
+      - pkg: mysql57_community_release


### PR DESCRIPTION
This commits my initial work for adding support for the official MySQL repositories.

Completed:
- Adding official MySQL repository to RHEL with MySQL 5.7 by default.
- Require repo state finishes before package installation if included.

TODOS:
- Add support for Debian, Ubuntu, Fedora and Suse packages on http://repo.mysql.com/
- Allow preferred version to trigger enabling/disabling of appropriate repos. Repos for 5.5, 5.6 and 8.0 are installed with package.