### PR TITLE
add ability to specify repeating keys

### DIFF
--- a/mysql/files/my.cnf
+++ b/mysql/files/my.cnf
@@ -31,7 +31,13 @@
 {% if mvalue == "noarg_present" -%}
 {{ mparam }}
 {%- else -%}
+{%- if mvalue is iterable and mvalue is not string -%}
+{%- for item in mvalue -%}
+{{ mparam }}{{ '='|indent(indents, true) }} {{ item }}
+{% endfor -%}
+{%- else -%}
 {{ mparam }}{{ '='|indent(indents, true) }} {{ mvalue }}
+{%- endif -%}
 {%- endif -%}
 {%- endfor -%}
 {%- endif -%}

--- a/pillar.example
+++ b/pillar.example
@@ -31,6 +31,11 @@ mysql:
       port: 3307
       binlog_do_db: foo
       auto_increment_increment: 5
+      binlog-ignore-db:
+       - mysql
+       - sys
+       - information_schema
+       - performance_schema
     mysql:
       # my.cnf param that not require value
       no-auto-rehash: noarg_present


### PR DESCRIPTION
Fix for https://github.com/saltstack-formulas/mysql-formula/issues/67
example:
```
binlog-ignore-db:
 - mysql
 - sys
 - information_schema
 - performance_schema
```