### PR TITLE
Do not template the MySQL version in debconf settings

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -22,11 +22,11 @@ mysql_debconf_utils:
 
 mysql_debconf:
   debconf.set:
-    - name: {{ mysql.server }}
+    - name: mysql-server
     - data:
-        '{{ mysql.server }}/root_password': {'type': 'password', 'value': '{{ mysql_root_password }}'}
-        '{{ mysql.server }}/root_password_again': {'type': 'password', 'value': '{{ mysql_root_password }}'}
-        '{{ mysql.server }}/start_on_boot': {'type': 'boolean', 'value': 'true'}
+        'mysql-server/root_password': {'type': 'password', 'value': '{{ mysql_root_password }}'}
+        'mysql-server/root_password_again': {'type': 'password', 'value': '{{ mysql_root_password }}'}
+        'mysql-server/start_on_boot': {'type': 'boolean', 'value': 'true'}
     - require_in:
       - pkg: {{ mysql.server }}
     - require:


### PR DESCRIPTION
On Ubuntu 14.04, MySQL looks for `mysql-server` keys in debconf no matter what version of `mysql-server` is installed. I tested this by adding a pillar config like:

```
mysql:
  server:
    root_password: foo
  lookups:
    server: mysql-server-5.6
    client: mysql-client-5.6
```

## Current behavior

With the current mysql-formula you will end up with a blank root password when `mysql-server-5.6` is installed. When using `sudo debconf-get-selections | grep mysql` I see that the formula adds entries for `mysql-server-5.6 mysql-formula-5.6/root_password`, etc.

The following will fail:
`mysql -u root -p"foo"` (you'll need to use a blank password)

## New behavior

On this branch the root password will be successfully applied. And `debconf` will show results as `mysql-server mysql-server/root_password`, etc.

You can now login appropriately:
`mysql -u root -p"foo"`