### PR TITLE
mysql.server formula fixes for gentoo

### DIFF
--- a/mysql/defaults.yaml
+++ b/mysql/defaults.yaml
@@ -327,7 +327,8 @@ Gentoo:
         user: mysql
         port: 3306
         socket: /var/run/mysqld/mysqld.sock
-        pid_file: /var/run/mysqld/mysqld.pid
+        # note: on gentoo the init.d script specifically relies on the variable called pid-file, so don't use the underscore
+        pid-file: /var/run/mysqld/mysqld.pid
         log_error: /var/log/mysql/mysqld.err
         basedir: /usr
         datadir: /var/lib/mysql

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -100,13 +100,23 @@ mysql_initialize:
       - pkg: {{ mysql.server }}
 {% endif %}
 
+{% if os_family in ['Gentoo'] %}
+mysql_initialize:
+  cmd.run:
+    - name: emerge --config {{ mysql.server }}
+    - user: root
+    - creates: {{ mysql_datadir}}/mysql/
+    - require:
+      - pkg: {{ mysql.server }}
+{% endif %}
+
 mysqld:
   service.running:
     - name: {{ mysql.service }}
     - enable: True
     - require:
       - pkg: {{ mysql.server }}
-{% if os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 %}
+{% if (os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7) or (os_family in ['Gentoo']) %}
       - cmd: mysql_initialize
 {% endif %}
     - watch:


### PR DESCRIPTION
mysql.server formula failed on gentoo because of hard-coded pid-file (pid_file is not detected as declared for gentoo defaults.yaml because the variable name for the pid-file is hard-coded in the init.d script installed by standard dev-db/mysql ebuild as pid-file (not pid_file)).

mysql.server formula also failed because it was missing the `emerge --config dev-db/mysql` step. This commit adds this as an alternative mysql_initialize step for the gentoo os_family.