### PR TITLE
Fix setting datadir to alternate dir with mariadb

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -89,13 +89,25 @@ mysqld-packages:
       - debconf: mysql_debconf
 {% endif %}
 
-{% if os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 %}
+{% if os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 and mysql.server == 'mysql-server' %}
 # Initialize mysql database with --initialize-insecure option before starting service so we don't get locked out.
 mysql_initialize:
   cmd.run:
     - name: mysqld --initialize-insecure --user=mysql --basedir=/usr --datadir={{ mysql_datadir }}
     - user: root
     - creates: {{ mysql_datadir}}/mysql/
+    - require:
+      - pkg: {{ mysql.server }}
+{% endif %}
+
+{% if os_family in ['RedHat', 'Suse'] and mysql.server == 'mariadb-server' %}
+# For MariaDB it's enough to only create the datadir
+mysql_initialize:
+  file.directory:
+    - name: {{ mysql_datadir }}
+    - user: mysql
+    - group: mysql
+    - makedirs: True
     - require:
       - pkg: {{ mysql.server }}
 {% endif %}
@@ -116,8 +128,10 @@ mysqld:
     - enable: True
     - require:
       - pkg: {{ mysql.server }}
-{% if (os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7) or (os_family in ['Gentoo']) %}
+{% if (os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 and mysql.server == 'mysql-server') or (os_family in ['Gentoo']) %}
       - cmd: mysql_initialize
+{% elif os_family in ['RedHat', 'Suse'] and mysql.server == 'mariadb-server' %}
+      - file: {{ mysql_datadir }}
 {% endif %}
     - watch:
       - pkg: {{ mysql.server }}

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -89,7 +89,7 @@ mysqld-packages:
       - debconf: mysql_debconf
 {% endif %}
 
-{% if os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 and mysql.server == 'mysql-server' %}
+{% if os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 and mysql.server != 'mariadb-server' %}
 # Initialize mysql database with --initialize-insecure option before starting service so we don't get locked out.
 mysql_initialize:
   cmd.run:
@@ -128,7 +128,7 @@ mysqld:
     - enable: True
     - require:
       - pkg: {{ mysql.server }}
-{% if (os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 and mysql.server == 'mysql-server') or (os_family in ['Gentoo']) %}
+{% if (os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 and mysql.server != 'mariadb-server') or (os_family in ['Gentoo']) %}
       - cmd: mysql_initialize
 {% elif os_family in ['RedHat', 'Suse'] and mysql.server == 'mariadb-server' %}
       - file: {{ mysql_datadir }}


### PR DESCRIPTION
When in MariaDB a new datadir is used, then the new datadir must exist before the service can start. When the service start it will install an empty database in the created dir. It doesn't work with 

This fix add a state which create an empty datadir, before the service will start.