### PR TITLE
Fix mysql.config for client only installations.

### DIFF
--- a/mysql/config.sls
+++ b/mysql/config.sls
@@ -70,8 +70,6 @@ mysql_clients_config:
 mysql_config:
   file.managed:
     - name: {{ mysql.config.file }}
-    - require:
-      - pkg: {{ mysql.server }}
     - template: jinja
 {% if "config_directory" in mysql %}
     - source: salt://mysql/files/my-include.cnf

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -88,6 +88,8 @@ mysqld-packages:
     - require:
       - debconf: mysql_debconf
 {% endif %}
+    - require_in:
+      - file: mysql_config
 
 {% if os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 %}
 # Initialize mysql database with --initialize-insecure option before starting service so we don't get locked out.


### PR DESCRIPTION
This fixes issue #127 

Without this patch your unable to modify */etc/mysql/my.cnf* without installing mysql.server.

This patch removes that requirement.

@gravyboat pinging you for the merge.