### PR TITLE
Hardcode 'mysql-server' as debconf base path for root password

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -24,8 +24,8 @@ mysql_debconf:
   debconf.set:
     - name: {{ mysql.server }}
     - data:
-        '{{ mysql.server }}/root_password': {'type': 'password', 'value': '{{ mysql_root_password }}'}
-        '{{ mysql.server }}/root_password_again': {'type': 'password', 'value': '{{ mysql_root_password }}'}
+        'mysql-server/root_password': {'type': 'password', 'value': '{{ mysql_root_password }}'}
+        'mysql-server/root_password_again': {'type': 'password', 'value': '{{ mysql_root_password }}'}
         '{{ mysql.server }}/start_on_boot': {'type': 'boolean', 'value': 'true'}
     - require_in:
       - pkg: {{ mysql.server }}


### PR DESCRIPTION
This is needed for correctly setting the root password when installing mariadb and addresses #43. 

The `mysql-server/root_password` and `mysql-server/root_password_again` debconf keys are used by mysql-server and mariadb-server and are referenced directly in the postinst scripts of the respective package.

