### PR TITLE
honorate mysql:server:host as in user declaration

### DIFF
--- a/mysql/user.sls
+++ b/mysql/user.sls
@@ -61,7 +61,7 @@ include:
     - grant_option: {{ user['grant_option'] | default(False) }}
     - user: {{ name }}
     - host: '{{ host }}'
-    - connection_host: localhost
+    - connection_host: '{{ mysql_host }}'
     - connection_user: '{{ mysql_salt_user }}'
     {% if mysql_salt_pass -%}
     - connection_pass: '{{ mysql_salt_pass }}'


### PR DESCRIPTION
From this formula, I can declare users on an external mysql server, but not grants:

> ----------
          ID: mysql_user_sync_10.0.0.1
    Function: mysql_user.present
        Name: sync
      Result: True
     Comment: User sync@10.0.0.1 is already present with the desired password
     Started: 09:50:15.029645
    Duration: 15.726 ms
     Changes:   
----------
          ID: mysql_user_sync_10.0.0.1_grants
    Function: mysql_grants.present
        Name: sync
      Result: False
     Comment: MySQL Error 2002: Can't connect to local MySQL server through socket '/var/lib/mysql/mysql.sock' (2)
     Started: 09:50:15.045862
    Duration: 0.925 ms
     Changes:   
