### PR TITLE
Fix duplicate ID if fqdn is localhost/localhost.localdomain

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -39,7 +39,7 @@ mysql_root_password:
     - require:
       - service: mysqld
 
-{% for host in ['localhost', 'localhost.localdomain', salt['grains.get']('fqdn')] %}
+{% for host in {'localhost': '', 'localhost.localdomain': '', salt['grains.get']('fqdn'): ''}.keys() %}
 mysql_delete_anonymous_user_{{ host }}:
   mysql_user:
     - absent


### PR DESCRIPTION
Fixes #152 by leveraging the nature of dicts in Python, thereby avoiding any duplicate IDs. Salt (and Jinja too eventually in its core) has introduced a `unique` filter (albeit currently [undocumented](https://github.com/saltstack/salt/issues/42717)) in v2017.5 but this would require the formula to move to that version or above.

This solves the problem in a backwards compatible way.