### PR TITLE
Allow the use of wildcards on a user's database/table names when defining grants.

### DIFF
--- a/mysql/user.sls
+++ b/mysql/user.sls
@@ -97,6 +97,7 @@ include:
     {% endif %}
     - user: {{ name }}
     - host: '{{ host }}'
+    - escape: {{ db['escape'] | default(True) }}
     - connection_host: '{{ mysql_host }}'
     - connection_user: '{{ mysql_salt_user }}'
     {% if mysql_salt_pass -%}

--- a/pillar.example
+++ b/pillar.example
@@ -85,6 +85,7 @@ mysql:
       databases:
         - database: foo
           grants: ['select', 'insert', 'update']
+          escape: True
         - database: bar
           grants: ['all privileges']
     bob:
@@ -96,9 +97,10 @@ mysql:
       ssl-ISSUER: Name
       ssl-CIPHER: Cipher
       databases:
-        - database: foo
+        - database: "foo_%%"
           grants: ['all privileges']
           grant_option: True
+          escape: False
         - database: bar
           table: foobar
           grants: ['select', 'insert', 'update', 'delete']

--- a/pillar.example
+++ b/pillar.example
@@ -97,7 +97,11 @@ mysql:
       ssl-ISSUER: Name
       ssl-CIPHER: Cipher
       databases:
-        - database: "foo_%%"
+        # https://github.com/saltstack/salt/issues/41178
+        # If you want to refer to databases using wildcards, turn off escape so
+        # the renderer does not escape them, enclose the string in '`' and
+        # use two '%'
+        - database: '`foo\_%%`'
           grants: ['all privileges']
           grant_option: True
           escape: False


### PR DESCRIPTION
Closes #111 

This is pretty much a remake of #112, but now the escape argument only gets to be used when database info is specified for a user. It also includes an entry using the wildcard in the `pillar.example` for the foo database.