### PR TITLE
FreeBSD support & opt-in state to enforce root password

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,12 @@ debconf.
     cryptographically insecure, future formula versions should use the
     newly available ``random.get_str`` method.
 
+``mysql.server_checks``
+-----------------------
+
+Enforces a root password to be set.
+
+
 ``mysql.disabled``
 ------------------
 

--- a/mysql/defaults.yaml
+++ b/mysql/defaults.yaml
@@ -368,7 +368,7 @@ FreeBSD:
   server: mysql56-server
   client: mysql56-client
   service: mysql-server
-  python: pymysql
+  python: py27-pymysql
   dev: mysql56-server
   config:
     file: /usr/local/etc/my.cnf

--- a/mysql/remove_test_database.sls
+++ b/mysql/remove_test_database.sls
@@ -12,6 +12,7 @@ mysql remove test database:
     - name: test
     - host: '{{ mysql_host }}'
     - connection_user: '{{ mysql_salt_user }}'
+    - connection_host: '{{ mysql_host }}'
     {% if mysql_salt_pass %}
     - connection_pass: '{{ mysql_salt_pass }}'
     {% endif %}

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -34,8 +34,8 @@ mysql_debconf:
 {% elif os_family in ['RedHat', 'Suse', 'FreeBSD'] %}
 mysql_root_password:
   cmd.run:
-    - name: mysqladmin --user {{ mysql_root_user }} password '{{ mysql_root_password|replace("'", "'\"'\"'") }}'
-    - unless: mysql --user {{ mysql_root_user }} --password='{{ mysql_root_password|replace("'", "'\"'\"'") }}' --execute="SELECT 1;"
+    - name: mysqladmin --host "{{ mysql_host }}" --user {{ mysql_root_user }} password '{{ mysql_root_password|replace("'", "'\"'\"'") }}'
+    - unless: mysql --host "{{ mysql_host }}" --user {{ mysql_root_user }} --password='{{ mysql_root_password|replace("'", "'\"'\"'") }}' --execute="SELECT 1;"
     - require:
       - service: mysqld
 

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -31,7 +31,7 @@ mysql_debconf:
       - pkg: {{ mysql.server }}
     - require:
       - pkg: mysql_debconf_utils
-{% elif os_family in ['RedHat', 'Suse'] %}
+{% elif os_family in ['RedHat', 'Suse', 'FreeBSD'] %}
 mysql_root_password:
   cmd.run:
     - name: mysqladmin --user {{ mysql_root_user }} password '{{ mysql_root_password|replace("'", "'\"'\"'") }}'

--- a/mysql/server_checks.sls
+++ b/mysql/server_checks.sls
@@ -1,0 +1,4 @@
+check_pillar_for_root_password:
+  test.check_pillar:
+    - present:
+      - mysql:server:root_password

--- a/pillar.example
+++ b/pillar.example
@@ -125,7 +125,9 @@ mysql:
 #    server: mysql-server
 #    client: mysql-client
 #    service: mysql-service
-#    python: python-mysqldb
+#  server:
+#    lookup:
+#      python: python-mysqldb
 
   # Install MySQL headers
   dev:


### PR DESCRIPTION
  - Fixed minor documentation error in `pillar.example`
  - FreeBSD uses `py27-pymysql` instead of `pymysql` (at least on 10.3)
  - FreeBSD uses the same way to set the root password as RedHat and Suse
  - New state `mysql.server_checks` prevents a "silent security fail" when no root password is set.