### PR TITLE
Default to MariaDB packages on Debian releases after stretch

### DIFF
--- a/mysql/defaults.yaml
+++ b/mysql/defaults.yaml
@@ -48,12 +48,20 @@ Ubuntu:
     append: |
       !includedir /etc/mysql/conf.d/
 Debian:
-  server: mysql-server
-  client: mysql-client
-  service: mysql
+  {%- if salt['grains.get']('osmajorrelease')|int >= 9 %}
+  {% set mysql_engine = 'mariadb' %}
+  {% set mysql_service = 'mysql' %}
+  {%- else %}
+  {% set mysql_engine = 'mysql' %}
+  {% set mysql_service = 'mysql' %}
+  {%- endif %}
+
+  server: {{ mysql_engine }}-server
+  service: {{ mysql_service }}
+  client: {{ mysql_engine }}-client
   python: python-mysqldb
   debconf_utils: debconf-utils
-  dev: libmysqlclient-dev
+  dev: lib{{ mysql_engine }}client-dev
   config:
     file: /etc/mysql/my.cnf
     sections:
@@ -90,6 +98,9 @@ Debian:
         key_buffer_size: 16M
     append: |
       !includedir /etc/mysql/conf.d/
+      # {% if salt['grains.get']('osmajorrelease')|int >= 9 -%}
+      # !includedir /etc/mysql/mariadb.conf.d/
+      # {%- endif %}
 CentOS:
   # https://mariadb.com/blog/rhel7-transition-mysql-mariadb-first-look
   {%- if salt['grains.get']('osmajorrelease')|int in [7] %}

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -24,13 +24,24 @@ mysql_debconf:
   debconf.set:
     - name: {{ mysql.server }}
     - data:
-        'mysql-server/root_password': {'type': 'password', 'value': '{{ mysql_root_password }}'}
-        'mysql-server/root_password_again': {'type': 'password', 'value': '{{ mysql_root_password }}'}
         '{{ mysql.server }}/start_on_boot': {'type': 'boolean', 'value': 'true'}
     - require_in:
       - pkg: {{ mysql.server }}
     - require:
       - pkg: mysql_debconf_utils
+
+{% if salt['grains.get']('osmajorrelease')|int < 9 or not salt['grains.get']('os')|lower == 'debian' %}
+mysql_password_debconf:
+  debconf.set:
+    - name: mysql-server
+    - data:
+        'mysql-server/root_password': {'type': 'password', 'value': '{{ mysql_root_password }}'}
+        'mysql-server/root_password_again': {'type': 'password', 'value': '{{ mysql_root_password }}'}
+    - require_in:
+      - pkg: {{ mysql.server }}
+    - require:
+      - pkg: mysql_debconf_utils
+
 {% elif os_family in ['RedHat', 'Suse', 'FreeBSD'] %}
 mysql_root_password:
   cmd.run:


### PR DESCRIPTION
This allows users to use this formula on Debian releases after (and including) stretch, which default to MariaDB. The password management is unnecessary as it is handled via socket activation.