### PR TITLE
Fix unbalanced if/endif

### DIFF
--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -41,6 +41,7 @@ mysql_password_debconf:
       - pkg: {{ mysql.server }}
     - require:
       - pkg: mysql_debconf_utils
+{% endif %}
 
 {% elif os_family in ['RedHat', 'Suse', 'FreeBSD'] %}
 mysql_root_password:


### PR DESCRIPTION
Commit 89985f7485ccefd71b0bc6327fa732dc3c43d39d added a {% if ... %}
without the closing {% endif %} which leads to a Jinja syntax error.

This commit adds the missing {% endif %}