### PR TITLE
Make SUSE package name compatible with Leap 42.x

### DIFF
--- a/mysql/defaults.yaml
+++ b/mysql/defaults.yaml
@@ -208,7 +208,12 @@ SUSE:
   server: mariadb
   client: mariadb-client
   service: mysql
-  python: python2-PyMySQL
+  {%- if salt['grains.get']('osmajorrelease')|int == 42 %}
+  # "old" package name up to Leap 42.x
+  python: python-PyMySQL
+  {% else %}
+  python: python2-pymysql
+  {% endif %}
   config:
     file: /etc/my.cnf
     sections:


### PR DESCRIPTION
python2-pymysql exists only in Leap 15 and Tumbleweed.

Up to Leap 42.3, the package is named python-pymysql.