### PR TITLE
Prevent None values in config files

### DIFF
--- a/mysql/files/client.cnf
+++ b/mysql/files/client.cnf
@@ -26,6 +26,7 @@
 
 [{{ sname }}]
 {%- for mparam, mvalue in sdata.items()|default([])|sort -%}
+{%- if mvalue is none %}{% continue %}{% endif -%}
 {%- set indents = 40 - mparam|count %}
 {% if mvalue == "noarg_present" -%}
 {{ mparam }}

--- a/mysql/files/galera.cnf
+++ b/mysql/files/galera.cnf
@@ -26,6 +26,7 @@
 
 [{{ sname }}]
 {%- for mparam, mvalue in sdata.items()|default([])|sort -%}
+{%- if mvalue is none %}{% continue %}{% endif -%}
 {%- set indents = 40 - mparam|count %}
 {% if mvalue == "noarg_present" -%}
 {{ mparam }}

--- a/mysql/files/my-include.cnf
+++ b/mysql/files/my-include.cnf
@@ -30,6 +30,7 @@
 
 [{{ sname }}]
 {%- for mparam, mvalue in sdata.items()|default([])|sort -%}
+{%- if mvalue is none %}{% continue %}{% endif -%}
 {%- set indents = 40 - mparam|count %}
 {% if mvalue == "noarg_present" -%}
 {{ mparam }}

--- a/mysql/files/my.cnf
+++ b/mysql/files/my.cnf
@@ -26,12 +26,14 @@
 
 [{{ sname }}]
 {%- for mparam, mvalue in sdata.items()|default([])|sort -%}
+{%- if mvalue is none %}{% continue %}{% endif -%}
 {%- set indents = 40 - mparam|count %}
 {% if mvalue == "noarg_present" -%}
 {{ mparam }}
 {%- else -%}
 {%- if mvalue is iterable and mvalue is not string -%}
 {%- for item in mvalue -%}
+{%- if item is none %}{% continue %}{% endif -%}
 {{ mparam }}{{ '='|indent(indents, true) }} {{ item }}
 {% endfor -%}
 {%- else -%}

--- a/mysql/files/mysql-clients.cnf
+++ b/mysql/files/mysql-clients.cnf
@@ -26,6 +26,7 @@
 
 [{{ sname }}]
 {%- for mparam, mvalue in sdata.items()|default([])|sort -%}
+{%- if mvalue is none %}{% continue %}{% endif -%}
 {%- set indents = 40 - mparam|count %}
 {% if mvalue == "noarg_present" -%}
 {{ mparam }}

--- a/mysql/files/server.cnf
+++ b/mysql/files/server.cnf
@@ -26,6 +26,7 @@
 
 [{{ sname }}]
 {%- for mparam, mvalue in sdata.items()|default([])|sort -%}
+{%- if mvalue is none %}{% continue %}{% endif -%}
 {%- set indents = 40 - mparam|count %}
 {% if mvalue == "noarg_present" -%}
 {{ mparam }}

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -84,7 +84,7 @@ mysql_install_datadir:
 {% else %}
     - name: mysql_install_db --user=mysql --basedir=/usr --datadir={{ mysql_datadir }}
 {% endif %}
-    - user: root
+    - runas: root
     - creates: {{ mysql_datadir }}/mysql/user.frm
     - env:
         - TMPDIR: '/tmp'
@@ -110,7 +110,7 @@ mysqld-packages:
 mysql_initialize:
   cmd.run:
     - name: mysqld --initialize-insecure --user=mysql --basedir=/usr --datadir={{ mysql_datadir }}
-    - user: root
+    - runas: root
     - creates: {{ mysql_datadir}}/mysql/
     - require:
       - pkg: {{ mysql.serverpkg }}
@@ -132,7 +132,7 @@ mysql_initialize:
 mysql_initialize:
   cmd.run:
     - name: emerge --config {{ mysql.serverpkg }}
-    - user: root
+    - runas: root
     - creates: {{ mysql_datadir}}/mysql/
     - require:
       - pkg: {{ mysql.serverpkg }}


### PR DESCRIPTION
- The default config of `mysqld.datadir` and `mysqld.user` in FreeBSD (and others) is `None`.  `None` is not a valid config value in this context. a779417 fixes this.
- `cmd.run` accepts `user`, but ignores it. Only `runas` actually changes the UID.

Tested on FreeBSD 11.2.