### PR TITLE
Fix MacOS desktop shortcuts

### DIFF
--- a/mysql/files/mac_shortcut.sh
+++ b/mysql/files/mac_shortcut.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
 CMD='/usr/bin/osascript -e'
-if [[ -f "{{ home }}/{{ user }}/Desktop/{{ app }}" ]] && [[ "${1}" -eq "remove" ]]
+
+if [[ -e "{{ home }}/{{ user }}/Desktop/{{ app }}" ]] && [[ "${1}" -eq "remove" ]]
 then
-    ${CMD} "tell application \"Finder\" to delete file \"{{home}}/{{user}}/Desktop/{{ app }}\""
-elif [[ -d "{{ dir }}/{{ app }}" ]] && [[ "${1}" -eq "add" ]]
+    $CMD "tell application \"Finder\" to delete POSIX file \"{{home}}/{{user}}/Desktop/{{ app }}\""
+elif [[ -e "{{ dir }}/{{ app ~ '.app' if suffix else app }}" ]] && [[ "${1}" -eq "add" ]]
 then
-    ${CMD} "tell application \"Finder\" to make new Alias at (path to desktop folder) to POSIX file \"{{ dir }}/{{ app }}\""
+    $CMD "tell application \"Finder\" to delete POSIX file \"{{home}}/{{user}}/Desktop/{{ app }}\"" >/dev/null 2>&1
+    $CMD "tell application \"Finder\" to make new Alias at (path to desktop folder) to POSIX file \"{{ dir }}/{{ app }}{{ suffix or '' }}\""
 fi

--- a/mysql/macos/install.sls
+++ b/mysql/macos/install.sls
@@ -90,8 +90,9 @@ mysql-macos-{{ product }}-desktop-shortcut-add:
     - context:
       user: {{ mysql.macos.user }}
       home: {{ mysql.macos.userhomes }}
-      dir: {{'/Applications/' ~ data.app ~ '.app' if "isapp" in data and data.isapp else dl.prefix ~ '/' ~ archivename ~ '/bin'}}
       app: {{ data.app }}
+      dir: {{ '/Applications' if "isapp" in data and data.isapp else dl.prefix ~ '/' ~ archivename ~ '/bin' }}
+      suffix: {{ '.app' if "isapp" in data and data.isapp else '' }}
   cmd.run:
     - name: /tmp/mac_shortcut.sh add
     - runas: {{ mysql.macos.user }}

--- a/mysql/macos/remove.sls
+++ b/mysql/macos/remove.sls
@@ -4,13 +4,13 @@
 {%- from salt.file.dirname(tpldir) ~ "/map.jinja" import mysql with context -%}
 
   {%- set dl = mysql.macos.dl %}
-  {%- for product, data in mysql.macos.products.items() if "enabled" in data and data.enabled %}
+  {%- for product, data in mysql.macos.products.items() if "app" in data and data.app and "url" in data and data.url  %}
       {%- set archivename = data.url.split('/')[-1]|replace('.dmg', '')|replace('.tar.gz', '')|replace('.zip', '') %}
 
 mysql-macos-{{ product }}-remove-destdir:
   file.absent:
     - names:
-      - {{ data.path }}
+      - {{ '/Applications' ~ data.app ~ '.app' if "isapp" in data and data.isapp else dl.prefix ~ '/' ~ archivename  }}
 
 mysql-macos-{{ product }}-desktop-shortcut-remove:
   file.managed:
@@ -21,8 +21,9 @@ mysql-macos-{{ product }}-desktop-shortcut-remove:
     - context:
       user: {{ mysql.macos.user }}
       home: {{ mysql.macos.userhomes }}
-      dir: {{'/Applications/' ~ data.app ~ '.app' if "isapp" in data and data.isapp else dl.prefix ~ '/' ~ archivename ~ '/bin'}}
       app: {{ data.app }}
+      dir: {{ '/Applications' if "isapp" in data and data.isapp else dl.prefix ~ '/' ~ archivename ~ '/bin' }}
+      suffix: {{ '.app' if "isapp" in data and data.isapp else '' }}
   cmd.run:
     - name: /tmp/mac_shortcut.sh remove
     - runas: {{ mysql.macos.user }}


### PR DESCRIPTION
This PR fixes "desktop shortcuts" on MacOS.
```
D: mysql-macos-workbench-desktop-shortcut-add
    Function: cmd.run
        Name: /tmp/mac_shortcut.sh add
      Result: True
     Comment: Command "/tmp/mac_shortcut.sh add" run
     Started: 22:01:58.317289
    Duration: 271.026 ms
     Changes:   
              ----------
              pid:
                  24010
              retcode:
                  0
              stderr:
              stdout:
                  alias file MySQLWorkbench of folder Desktop of folder messi of folder Users of startup disk


          ID: mysql-macos-community_server-desktop-shortcut-add
    Function: cmd.run
        Name: /tmp/mac_shortcut.sh add
      Result: True
     Comment: Command "/tmp/mac_shortcut.sh add" run
     Started: 22:04:30.405989
    Duration: 277.031 ms
     Changes:   
              ----------
              pid:
                  24066
              retcode:
                  0
              stderr:
              stdout:
                  alias file mysql of folder Desktop of folder messi of folder Users of startup disk
```