### PR TITLE
Updated example pillar name overrides to match new keys

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -121,13 +121,12 @@ mysql:
           grants: ['select', 'insert', 'update']
 
   # Override any names defined in map.jinja
-#  lookup:
-#    server: mysql-server
-#    client: mysql-client
-#    service: mysql-service
-#  server:
-#    lookup:
-#      python: python-mysqldb
+  # serverpkg: mysql-server
+  # clientpkg: mysql-client
+  # service: mysql
+  # pythonpkg: python-mysqldb
+  # devpkg: mysql-devel
+  # debconf_utils: debconf-utils
 
   # Install MySQL headers
   dev:


### PR DESCRIPTION
At some point the key names were changed but the example wasn't updated as well.