### PR TITLE
Some minor fixes for CentOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,3 +118,20 @@ Add the official MySQL 5.7 repository.
     Debian and Suse support to be added. Also need to add the option to allow
     selection of MySQL version (5.6 and 5.5 repos are added but disabled) and
     changed enabled repository accordingly.
+
+``mysql.config``
+------------------
+
+Manage the MySQL configuration.
+
+.. note::
+    There are currently two common ways to configure MySQL, a monolithic configuration file
+    or a configuration directory with configuration files per component. By default this
+    state will use a configuration directory for CentOS and Fedora, and a monolithic
+    configuration file for all other supported OSes.
+
+    Whether the configuration directory is used or not depends on whether `mysql.config_directory`
+    is defined in the pillar. If it is present it will pick the configuration from individual
+    component keys (`mysql.server`, `mysql.galera`, `mysql.libraries`, etc) with optional global
+    configuration from `mysql.global`. The monolithic configuration, however, is defined separately
+    in `mysql.config`.

--- a/mysql/config.sls
+++ b/mysql/config.sls
@@ -25,6 +25,8 @@ mysql_server_config:
     - group: root
     - mode: 644
     {% endif %}
+    - require:
+      - file: mysql_config_directory
 {% endif %}
 
 {% if "galera_config" in mysql %}
@@ -40,6 +42,8 @@ mysql_galera_config:
     - group: root
     - mode: 644
     {% endif %}
+    - require:
+      - file: mysql_config_directory
 {% endif %}
 
 {% if "library_config" in mysql %}
@@ -55,6 +59,8 @@ mysql_library_config:
     - group: root
     - mode: 644
     {% endif %}
+    - require:
+      - file: mysql_config_directory
 {% endif %}
 
 {% if "clients_config" in mysql %}
@@ -70,6 +76,8 @@ mysql_clients_config:
     - group: root
     - mode: 644
     {% endif %}
+    - require:
+      - file: mysql_config_directory
 {% endif %}
 
 {% endif %}

--- a/mysql/files/my-include.cnf
+++ b/mysql/files/my-include.cnf
@@ -9,10 +9,10 @@
 {#-
 ===== COMBINE DATA =====
 -#}
-{%- if "sections" in mysql.config -%}
-{%- set goodParamList = mysql.config.sections -%}
+{%- if "global_config" in mysql and "sections" in mysql.global_config -%}
+{%- set goodParamList = mysql.global_config.sections -%}
 {%- for section_name in supported_sections -%}
-    {%- set sectdict = mysql.config.sections[section_name] | default({}) -%}
+    {%- set sectdict = mysql.global_config.sections[section_name] | default({}) -%}
     {%- for mparam, mvalue in salt['pillar.get']('mysql:global:'+section_name, {}).items() -%}
         {%- set mparamUnderscore = mparam | replace('-','_') -%}
         {%- do sectdict.update({mparamUnderscore:mvalue}) -%}

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -104,6 +104,9 @@ mysqld-packages:
 {% endif %}
     - require_in:
       - file: mysql_config
+{% if "config_directory" in mysql %}
+      - file: mysql_config_directory
+{% endif %}
 
 {% if os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 and mysql.serverpkg.lower() != 'mariadb-server' %}
 # Initialize mysql database with --initialize-insecure option before starting service so we don't get locked out.

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -105,7 +105,7 @@ mysqld-packages:
     - require_in:
       - file: mysql_config
 
-{% if os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 and mysql.serverpkg != 'mariadb-server' %}
+{% if os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 and mysql.serverpkg.lower() != 'mariadb-server' %}
 # Initialize mysql database with --initialize-insecure option before starting service so we don't get locked out.
 mysql_initialize:
   cmd.run:
@@ -116,7 +116,7 @@ mysql_initialize:
       - pkg: {{ mysql.serverpkg }}
 {% endif %}
 
-{% if os_family in ['RedHat', 'Suse'] and mysql.serverpkg == 'mariadb-server' %}
+{% if os_family in ['RedHat', 'Suse'] and mysql.serverpkg.lower() == 'mariadb-server' %}
 # For MariaDB it's enough to only create the datadir
 mysql_initialize:
   file.directory:
@@ -144,9 +144,9 @@ mysqld:
     - enable: True
     - require:
       - pkg: {{ mysql.serverpkg }}
-{% if (os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 and mysql.serverpkg != 'mariadb-server') or (os_family in ['Gentoo']) %}
+{% if (os_family in ['RedHat', 'Suse'] and mysql.version is defined and mysql.version >= 5.7 and mysql.serverpkg.lower() != 'mariadb-server') or (os_family in ['Gentoo']) %}
       - cmd: mysql_initialize
-{% elif os_family in ['RedHat', 'Suse'] and mysql.serverpkg == 'mariadb-server' %}
+{% elif os_family in ['RedHat', 'Suse'] and mysql.serverpkg.lower() == 'mariadb-server' %}
       - file: {{ mysql_datadir }}
 {% endif %}
     - watch:


### PR DESCRIPTION
These are some minor fixes for CentOS when using the yum repo from MariaDB upstream.

- Fix my-include.conf so it's possible again to have an empty global configuration. Otherwise the values defined in defaults.yaml are almost impossible to get rid of if you don't want them
- Package name can be 'mariadb-server' (distro package) or 'MariaDB-server' (MariaDB upstream package)
- Make sure the config directory and files under it are also only handled after the server package is installed, and not just /etc/my.cnf