### PR TITLE
Apparmor support

### DIFF
--- a/mysql/defaults.yaml
+++ b/mysql/defaults.yaml
@@ -20,6 +20,9 @@ mysql:
         socket: /var/run/mysqld/mysqld.sock
         port: 3306
         datadir: /var/lib/mysql
+    apparmor:
+      dir: /etc/apparmor.d/local
+      file: usr.sbin.mysqld
 
   macos:
     userhomes: /Users


### PR DESCRIPTION
PR to resolve issue [cannot install mysql](https://askubuntu.com/questions/1098074/mysql-fails-to-install-on-ubuntu-18-10) and probably [cannot create /var/lib/mysql](https://askubuntu.com/questions/1091843/mysql-cant-install-on-ubuntu-18-04-becasue-it-cant-create-directory-var-lib-mys) issue too.


```
          ID: mysqld-service-running
    Function: file.append
        Name: /etc/apparmor.d/local/usr.sbin.mysqld
      Result: True
     Comment: Appended 2 lines
     Started: 06:12:02.143185
    Duration: 945.954 ms
     Changes:   
              ----------
              diff:
                  --- 
                  
                  +++ 
                  
                  @@ -0,0 +1,2 @@
                  
                  +/var/lib/mysql/ r,
                  +/var/lib/mysql/** rwk,

...
   ID: mysqld-service-running
    Function: service.running
        Name: mysql
      Result: True
     Comment: Service restarted
     Started: 06:12:03.117972
    Duration: 3082.849 ms
     Changes:   
              ----------
              mysql:
                  True
```