### PR TITLE
Include pillar example for granting permissions to user on Any host

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -111,7 +111,7 @@ mysql:
           grants: ['all privileges']
     bob:
       password_hash: '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'
-      host: localhost
+      host: '%' # Any host
       ssl: True
       ssl-X509: True
       ssl-SUBJECT: Subject


### PR DESCRIPTION
It wasn't obvious to me how to enable this in the formula so I thought I'd document it for others.