### PR TITLE
Update hash for MySQL community server RPM repo

### DIFF
--- a/mysql/repo.sls
+++ b/mysql/repo.sls
@@ -20,7 +20,7 @@ include:
 # A lookup table for MySQL Repo GPG keys & RPM URLs for various RedHat releases
   {% set pkg = {
     'key': 'http://repo.mysql.com/RPM-GPG-KEY-mysql',
-    'key_hash': 'md5=472a4a4867adfd31a68e8c9bbfacc23d',
+    'key_hash': 'md5=162ec8cb41add661b357e926a083b0cc',
     'rpm': rpm_source
  } %}
 


### PR DESCRIPTION
[`RPM-GPG-KEY-mysql` was last modified at 18-Jan-2019 07:13](http://repo.mysql.com/)