### PR TITLE
Remove DB and/or user

### DIFF
--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -13,18 +13,28 @@ include:
 
 {% for database_obj in salt['pillar.get']('mysql:database', []) %}
 {% set state_id = 'mysql_db_' ~ loop.index0 %}
-{% set database = database_obj.get('name') if database_obj is mapping else database_obj %}
+{% if database_obj is mapping %}
+{%   set database = database_obj.get('name') %}
+{%   set present = database_obj.get('present', True) %}
+{% else %}
+{%   set database = database_obj %}
+{%   set present = True %}
+{% endif %}
 {{ state_id }}:
+  {%- if present %}
   mysql_database.present:
+    {% if database_obj is mapping %}
+    - character_set: {{ database_obj.get('character_set', '') }}
+    - collate: {{ database_obj.get('collate', '') }}
+    {% endif %}
+  {% else %}
+  mysql_database.absent:
+  {% endif %}
     - name: {{ database }}
     - connection_host: '{{ mysql_host }}'
     - connection_user: '{{ mysql_salt_user }}'
     {% if mysql_salt_pass %}
     - connection_pass: '{{ mysql_salt_pass }}'
-    {% endif %}
-    {% if database_obj is mapping %}
-    - character_set: {{ database_obj.get('character_set', '') }}
-    - collate: {{ database_obj.get('collate', '') }}
     {% endif %}
     - connection_charset: utf8
 

--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -13,7 +13,9 @@ include:
 
 {% for database_obj in salt['pillar.get']('mysql:database', []) %}
 {% set state_id = 'mysql_db_' ~ loop.index0 %}
-{% if database_obj is mapping %}
+{% if not database_obj %}{# in case database_obj == [] #}
+{%   continue %}
+{% elif database_obj is mapping %}
 {%   set database = database_obj.get('name') %}
 {%   set present = database_obj.get('present', True) %}
 {% else %}

--- a/mysql/user.sls
+++ b/mysql/user.sls
@@ -34,22 +34,28 @@ include:
 
 {% set state_id = 'mysql_user_' ~ name ~ '_' ~ host%}
 {{ state_id }}:
-  mysql_user.present:
-    - name: {{ name }}
-    - host: '{{ host }}'
-  {%- if user['password_hash'] is defined %}
-    - password_hash: '{{ user['password_hash'] }}'
-  {%- elif user['password'] is defined and user['password'] != None %}
-    - password: '{{ user['password'] }}'
+  {%- if user.get('present', True) %}
+    mysql_user.present:
+      - name: {{ name }}
+      - host: '{{ host }}'
+    {%- if user['password_hash'] is defined %}
+      - password_hash: '{{ user['password_hash'] }}'
+    {%- elif user['password'] is defined and user['password'] != None %}
+      - password: '{{ user['password'] }}'
+    {%- else %}
+      - allow_passwordless: True
+    {%- endif %}
   {%- else %}
-    - allow_passwordless: True
+    mysql_user.absent:
+      - name: {{ name }}
+      - host: '{{ host }}'
   {%- endif %}
-    - connection_host: '{{ mysql_host }}'
-    - connection_user: '{{ mysql_salt_user }}'
-    {% if mysql_salt_pass %}
-    - connection_pass: '{{ mysql_salt_pass }}'
-    {% endif %}
-    - connection_charset: utf8
+      - connection_host: '{{ mysql_host }}'
+      - connection_user: '{{ mysql_salt_user }}'
+  {%- if mysql_salt_pass %}
+      - connection_pass: '{{ mysql_salt_pass }}'
+  {%- endif %}
+      - connection_charset: utf8
 
 {%- if 'grants' in user %}
 {{ state_id ~ '_grants' }}:

--- a/pillar.example
+++ b/pillar.example
@@ -143,6 +143,12 @@ mysql:
         - database: foo
           grants: ['select', 'insert', 'update']
 
+    # Remove a user
+    obsoleteuser:
+      host: localhost
+      # defaults to True
+      present: False
+
   # Override any names defined in map.jinja
   # serverpkg: mysql-server
   # clientpkg: mysql-client

--- a/pillar.example
+++ b/pillar.example
@@ -72,6 +72,9 @@ mysql:
     - name: bar
       character_set: utf8
       collate: utf8_general_ci
+    # Delete DB
+    - name: obsolete_db
+      present: False
   schema:
     foo:
       load: True


### PR DESCRIPTION
Adds the ability to remove

- a DB
- a DB user (user-host tuple to be specific)

Tested on FreeBSD 11.2 with Salt 2019.2, Python 3.6, MySQL 5.6.

Includes documentation in `pillar.example`.