### PR TITLE
feat(linux): archlinux support (no osmajorrelase grain)

### DIFF
--- a/mysql/osfamilymap.yaml
+++ b/mysql/osfamilymap.yaml
@@ -2,7 +2,7 @@
 #
 
 Debian:
-    {% if salt['grains.get']('osmajorrelease')|int >= 9 %}
+    {% if 'osmajorrelease' in grains and salt['grains.get']('osmajorrelease')|int >= 9 %}
   serverpkg: mariadb-server
   service: mariadb
   clientpkg: mariadb-client
@@ -42,13 +42,13 @@ Debian:
         key_buffer_size: 16M
     append: |
       !includedir /etc/mysql/conf.d/
-      # {% if salt['grains.get']('osmajorrelease')|int >= 9 -%}
+      # {% if 'osmajorrelease' in grains and salt['grains.get']('osmajorrelease')|int >= 9 -%}
       # !includedir /etc/mysql/mariadb.conf.d/
       # {%- endif %}
 
 RedHat:
   #https://mariadb.com/blog/rhel7-transition-mysql-mariadb-first-look
-   {%- if salt['grains.get']('osmajorrelease')|int in [7] %}
+   {%- if 'osmajorrelease' in grains and salt['grains.get']('osmajorrelease')|int in [7] %}
      {% set fork = 'mariadb' %}
   serverpkg: mariadb-server
   service: mariadb
@@ -75,7 +75,7 @@ RedHat:
 Suse:
   serverpkg: mariadb
   clientpkg: mariadb-client
-  {%- if salt['grains.get']('osmajorrelease')|int == 42 %}
+  {%- if 'osmajorrelease' in grains and salt['grains.get']('osmajorrelease')|int == 42 %}
     # "old" package name up to Leap 42.x
   pythonpkg: python-PyMySQL
     {% else %}

--- a/mysql/osmap.yaml
+++ b/mysql/osmap.yaml
@@ -24,7 +24,7 @@ Ubuntu:
 
 CentOS:
   # https://mariadb.com/blog/rhel7-transition-mysql-mariadb-first-look
-  {%- if salt['grains.get']('osmajorrelease')|int in [7] %}
+  {%- if 'osmajorrelease' in grains and salt['grains.get']('osmajorrelease')|int in [7] %}
     {% set fork = 'mariadb' %}
     {% set service = 'mariadb' %}
   {%- else %}

--- a/mysql/repo.sls
+++ b/mysql/repo.sls
@@ -6,7 +6,7 @@ include:
 # Completely ignore non-RHEL based systems
 # TODO: Add Debian and Suse systems.
 # TODO: Allow user to specify MySQL version and alter yum repo file accordingly.
-{% if grains['os_family'] == 'RedHat' %}
+{% if grains['os_family'] == 'RedHat' and `osmajorrelease` in grains %}
   {% if grains['osmajorrelease']|int == 5 %}
   {% set rpm_source = "http://repo.mysql.com/mysql57-community-release-el5.rpm" %}
   {% elif grains['osmajorrelease']|int == 6 %}

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -29,7 +29,7 @@ mysql_debconf:
     - require:
       - pkg: mysql_debconf_utils
 
-  {% if salt['grains.get']('osmajorrelease')|int < 9 or not salt['grains.get']('os')|lower == 'debian' %}
+  {% if 'osmajorrelease' in grains and salt['grains.get']('osmajorrelease')|int < 9 or not salt['grains.get']('os')|lower == 'debian' %}
 
 mysql_password_debconf:
   debconf.set:


### PR DESCRIPTION
This PR fixes general jinja rendering errors on Archlinx - no `osmajorrelase` grain.