### PR TITLE
fix(connector): fix typos (connnector) and missing `enabled`

### DIFF
--- a/mysql/defaults.yaml
+++ b/mysql/defaults.yaml
@@ -82,7 +82,8 @@ mysql:
         enabled: False
         url: https://downloads.mysql.com/archives/get/file/mysql-proxy-0.8.5-osx10.7-x86-32bit.tar.gz
         sum: 'md5=107df22412aa8c483d2021e1af24ee22'
-      connnector:
+      connector:
+        enabled: False
         url: https://downloads.mysql.com/archives/get/file/mysql-connector-nodejs-8.0.11.tar.gz
         sum: 'md5=dece7fe5607918ba68499ef07c31508d'
       forvisualstudio:

--- a/pillar.example
+++ b/pillar.example
@@ -195,7 +195,7 @@ mysql:
         enabled: False  #default
         url: https://downloads.mysql.com/archives/get/file/mysql-proxy-0.8.5-osx10.7-x86-32bit.tar.gz
         sum: 'md5=107df22412aa8c483d2021e1af24ee22'
-      connnector:
+      connector:
         enabled: False  #default
         url: https://downloads.mysql.com/archives/get/file/mysql-connector-nodejs-8.0.11.tar.gz
         sum: 'md5=dece7fe5607918ba68499ef07c31508d'

--- a/test/salt/pillar/mysql.sls
+++ b/test/salt/pillar/mysql.sls
@@ -194,7 +194,7 @@ mysql:
         enabled: False  #default
         url: https://downloads.mysql.com/archives/get/file/mysql-proxy-0.8.5-osx10.7-x86-32bit.tar.gz
         sum: 'md5=107df22412aa8c483d2021e1af24ee22'
-      connnector:
+      connector:
         enabled: False  #default
         url: https://downloads.mysql.com/archives/get/file/mysql-connector-nodejs-8.0.11.tar.gz
         sum: 'md5=dece7fe5607918ba68499ef07c31508d'


### PR DESCRIPTION
The `enabled` has to be set in `defaults.yaml`, as mentioned in the comments of the other two files.