### PR TITLE
Remove mysql.config include on mysql.repo

### DIFF
--- a/mysql/repo.sls
+++ b/mysql/repo.sls
@@ -1,6 +1,3 @@
-include:
-  - .config
-
 {% from tpldir ~ "/map.jinja" import mysql with context %}
 
 # Completely ignore non-RHEL based systems


### PR DESCRIPTION
mysql.config state is not needed on mysql.repo.
Removing the include allows users to manage the repository settings without overwriting MySQL configuration.