### PR TITLE
ci(yamllint): add rule `empty-values` & use new `yaml-files` setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,9 @@ jobs:
       before_install: skip
       script:
         # Install and run `yamllint`
-        - pip install --user yamllint
-        # yamllint disable-line rule:line-length
-        - yamllint -s . .yamllint pillar.example test/salt/pillar/mysql.sls
+        # Need at least `v1.17.0` for the `yaml-files` setting
+        - pip install --user yamllint>=1.17.0
+        - yamllint -s .
         # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D

--- a/.yamllint
+++ b/.yamllint
@@ -6,12 +6,26 @@ extends: default
 
 # Files to ignore completely
 # 1. All YAML files under directory `node_modules/`, introduced during the Travis run
-# 2. Any YAML files using Jinja (result in `yamllint` syntax errors)
+# 2. Any SLS files under directory `test/`, which are actually state files
+# 3. Any YAML files using Jinja (result in `yamllint` syntax errors)
 ignore: |
   node_modules/
+  test/**/states/**/*.sls
   mysql/supported_sections.yaml
 
+yaml-files:
+  # Default settings
+  - '*.yaml'
+  - '*.yml'
+  - .yamllint
+  # SaltStack Formulas additional settings
+  - '*.example'
+  - test/**/*.sls
+
 rules:
+  empty-values:
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
   line-length:
     # Increase from default of `80`
     # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)

--- a/mysql/defaults.yaml
+++ b/mysql/defaults.yaml
@@ -26,8 +26,9 @@ mysql:
 
   macos:
     userhomes: /Users
-    user:
-    group:
+    # `user` and `group` are set from `map.jinja`
+    # user: ~
+    # group: ~
     dl:
       tmpdir: /tmp/mysqltmp
       prefix: /usr/local

--- a/mysql/osfamilymap.yaml
+++ b/mysql/osfamilymap.yaml
@@ -43,7 +43,7 @@ RedHat:
   config:
     file: /etc/my.cnf
     sections:
-      client:
+      client: {}
       mysqld_safe:
         log_error: /var/log/mysql/mysqld.log
         pid_file: /var/run/mysql/mysqld.pid
@@ -63,11 +63,14 @@ Suse:
       client:
         socket: /var/run/mysql/mysql.sock
       mysqld:
+        # Empty values below to be resolved, disabling the rule in the meantime
+        # yamllint disable rule:empty-values
         port:
         user:
         socket:
         datadir:
         tmpdir:
+        # yamllint enable rule:empty-values
         innodb_file_format: Barracuda
         innodb_file_per_table: 'ON'
         server-id: 1
@@ -84,6 +87,8 @@ Arch:
   clientpkg: mariadb-clients
   service: mysqld
   pythonpkg: mysql-python
+  # Empty value below to be resolved, disabling the rule in the meantime
+  # yamllint disable-line rule:empty-values
   dev:
 
   config:
@@ -213,8 +218,11 @@ FreeBSD:
       client:
         socket: /tmp/mysql.sock
       mysqld:
+        # Empty values below to be resolved, disabling the rule in the meantime
+        # yamllint disable rule:empty-values
         user:
         datadir:
+        # yamllint enable rule:empty-values
         socket: /tmp/mysql.sock
         skip-external-locking: noarg_present
         key_buffer_size: 16M


### PR DESCRIPTION
* Semi-automated using https://github.com/myii/ssf-formula/pull/27
* Fix (or ignore) errors shown below:

```bash
mysql-formula$ yamllint -s .
./mysql/osfamilymap.yaml
  46:14     error    empty value in block mapping  (empty-values)
  66:14     error    empty value in block mapping  (empty-values)
  67:14     error    empty value in block mapping  (empty-values)
  68:16     error    empty value in block mapping  (empty-values)
  69:17     error    empty value in block mapping  (empty-values)
  70:16     error    empty value in block mapping  (empty-values)
  87:7      error    empty value in block mapping  (empty-values)
  216:14    error    empty value in block mapping  (empty-values)
  217:17    error    empty value in block mapping  (empty-values)

./mysql/defaults.yaml
  29:10     error    empty value in block mapping  (empty-values)
  30:11     error    empty value in block mapping  (empty-values)
```
