### PR TITLE
fix(db_load): preserve whitespace between -h and -p on the db load `c…

### DIFF
--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -56,7 +56,7 @@ include:
 
 {{ state_id }}_load:
   cmd.wait:
-    - name: mysql -u {{ mysql_salt_user }} -h{{ mysql_host }} {%- if mysql_salt_pass %}-p{%- endif %}{{ mysql_salt_pass }} {{ database }} < /etc/mysql/{{ database }}.schema
+    - name: mysql -u {{ mysql_salt_user }} -h{{ mysql_host }} {% if mysql_salt_pass %}-p{%- endif %}{{ mysql_salt_pass }} {{ database }} < /etc/mysql/{{ database }}.schema
     - watch:
       - file: {{ state_id }}_schema
       - mysql_database: {{ state_id }}


### PR DESCRIPTION
…md.wait`

When loading a file into a database on creation, the generated `cmd.wait` used to be:
```
mysql -u root -hlocalhost-p1889959522 db < ./db.schema
```
which failed.
This fix permit to preserve whitespace between -h -p flags


