### PR TITLE
fix: hide passwords when applying states

### DIFF
--- a/mysql/database.sls
+++ b/mysql/database.sls
@@ -60,7 +60,10 @@ include:
 
 {{ state_id }}_load:
   cmd.run:
-    - name: mysql -u {{ mysql_salt_user }} -h{{ mysql_host }} {% if mysql_salt_pass %}-p{%- endif %}{{ mysql_salt_pass }} {{ database }} < /etc/mysql/{{ database }}.schema
+    - name: mysql -u {{ mysql_salt_user }} -h{{ mysql_host }} {% if mysql_salt_pass %}-p{%- endif %}$SALT_PASS {{ database }} < /etc/mysql/{{ database }}.schema
+    - env:
+      - SALT_PASS: "{{ mysql_salt_pass }}"
+    - output_loglevel: quiet
     - onchanges:
       - file: {{ state_id }}_schema
       - mysql_database: {{ state_id }}

--- a/mysql/server.sls
+++ b/mysql/server.sls
@@ -97,8 +97,11 @@ mysql_password_debconf:
 {%-   elif os_family in ['RedHat', 'Suse', 'FreeBSD'] %}
 mysql_root_password:
   cmd.run:
-    - name: mysqladmin --host "{{ mysql_host }}" --user {{ mysql_root_user }} password '{{ mysql_root_password|replace("'", "'\"'\"'") }}'
-    - unless: mysql --host "{{ mysql_host }}" --user {{ mysql_root_user }} --password='{{ mysql_root_password|replace("'", "'\"'\"'") }}' --execute="SELECT 1;"
+    - name: mysqladmin --host "{{ mysql_host }}" --user {{ mysql_root_user }} password $SALT_PASS
+    - unless: mysql --host "{{ mysql_host }}" --user {{ mysql_root_user }} --password=$SALT_PASS --execute="SELECT 1;"
+    - env:
+      - SALT_PASS: "{{ mysql_root_password|replace("'", "'\"'\"'") }}"
+    - output_loglevel: quiet
     - require:
       - service: mysqld-service-running
 


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->
https://github.com/saltstack-formulas/mysql-formula/issues/258
https://github.com/saltstack-formulas/mysql-formula/issues/75


### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->
Use environment variables and output_loglevel values to ensure passwords are not displayed during state runs or in log files for relevant cmd.run states

This is not perfect as the rendered YAML for the state in debug logs will still show the password, but it hides it from the standard output.


### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->
None, existing tests will be fine


### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->
```
Running state [mysql -u root -hlocalhost -p$SALT_PASS smp < /etc/mysql/smp.schema] at time 22:56:03.198010
Executing state cmd.run for [mysql -u root -hlocalhost -p$SALT_PASS db < /etc/mysql/db.schema]
{'pid': 12967, 'retcode': 0, 'stdout': '', 'stderr': ''}
Completed state [mysql -u root -hlocalhost -p$SALT_PASS db < /etc/mysql/db.schema] at time 22:56:03.238271 (duration_in_ms=40.26)
LazyLoaded mysql_user.present


ID: mysql_db_0_load
Function: cmd.run
Name: mysql -u root -hlocalhost -p$SALT_PASS db < /etc/mysql/db.schema
Result: True
Comment: Command "mysql -u root -hlocalhost -p$SALT_PASS db < /etc/mysql/db.schema" run
Started: 22:56:03.198011
Duration: 40.26 ms
Changes:   
----------
pid:
  12967
retcode:
  0
stderr:
stdout:
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->
Have been running a production environment with these changes for over a year without issue.